### PR TITLE
put serialization into repo for performance

### DIFF
--- a/cmd/gravity/main.go
+++ b/cmd/gravity/main.go
@@ -174,7 +174,7 @@ func healthzHandler(server *app.Server) func(http.ResponseWriter, *http.Request)
 
 func statusHandler(server *app.Server, name, hash string) func(http.ResponseWriter, *http.Request) {
 	return func(writer http.ResponseWriter, request *http.Request) {
-		position, exist, err := server.PositionCache.Get()
+		position, exist, err := server.PositionCache.GetWithRawValue()
 		if err != nil || !exist {
 			writer.WriteHeader(http.StatusInternalServerError)
 			log.Error("[statusHandler] failed to get position, exist: %v, err: %v", exist, errors.ErrorStack(err))
@@ -186,10 +186,15 @@ func statusHandler(server *app.Server, name, hash string) func(http.ResponseWrit
 			state = core.ReportStageFull
 		}
 
+		s, ok := position.Value.(string)
+		if !ok {
+			log.Errorf("[statusHandler] invalid raw value type")
+		}
+
 		ret := core.TaskReportStatus{
 			Name:       name,
 			ConfigHash: hash,
-			Position:   position.Value,
+			Position:   s,
 			Stage:      state,
 			Version:    utils.Version,
 		}

--- a/cmd/gravity/main.go
+++ b/cmd/gravity/main.go
@@ -174,7 +174,7 @@ func healthzHandler(server *app.Server) func(http.ResponseWriter, *http.Request)
 
 func statusHandler(server *app.Server, name, hash string) func(http.ResponseWriter, *http.Request) {
 	return func(writer http.ResponseWriter, request *http.Request) {
-		position, exist, err := server.PositionCache.GetWithValueString()
+		position, v, exist, err := server.PositionCache.GetWithValueString()
 		if err != nil || !exist {
 			writer.WriteHeader(http.StatusInternalServerError)
 			log.Error("[statusHandler] failed to get positionRepoModel, exist: %v, err: %v", exist, errors.ErrorStack(err))
@@ -189,7 +189,7 @@ func statusHandler(server *app.Server, name, hash string) func(http.ResponseWrit
 		ret := core.TaskReportStatus{
 			Name:       name,
 			ConfigHash: hash,
-			Position:   position.ValueString,
+			Position:   v,
 			Stage:      state,
 			Version:    utils.Version,
 		}

--- a/cmd/gravity/main.go
+++ b/cmd/gravity/main.go
@@ -174,7 +174,7 @@ func healthzHandler(server *app.Server) func(http.ResponseWriter, *http.Request)
 
 func statusHandler(server *app.Server, name, hash string) func(http.ResponseWriter, *http.Request) {
 	return func(writer http.ResponseWriter, request *http.Request) {
-		positionRepoModel, exist, err := server.PositionCache.GetWithRawValue()
+		position, exist, err := server.PositionCache.GetWithValueString()
 		if err != nil || !exist {
 			writer.WriteHeader(http.StatusInternalServerError)
 			log.Error("[statusHandler] failed to get positionRepoModel, exist: %v, err: %v", exist, errors.ErrorStack(err))
@@ -182,14 +182,14 @@ func statusHandler(server *app.Server, name, hash string) func(http.ResponseWrit
 		}
 
 		var state = core.ReportStageIncremental
-		if positionRepoModel.Stage == string(config.Batch) {
+		if position.Stage == config.Batch {
 			state = core.ReportStageFull
 		}
 
 		ret := core.TaskReportStatus{
 			Name:       name,
 			ConfigHash: hash,
-			Position:   positionRepoModel.Value,
+			Position:   position.ValueString,
 			Stage:      state,
 			Version:    utils.Version,
 		}

--- a/cmd/gravity/main.go
+++ b/cmd/gravity/main.go
@@ -174,27 +174,22 @@ func healthzHandler(server *app.Server) func(http.ResponseWriter, *http.Request)
 
 func statusHandler(server *app.Server, name, hash string) func(http.ResponseWriter, *http.Request) {
 	return func(writer http.ResponseWriter, request *http.Request) {
-		position, exist, err := server.PositionCache.GetWithRawValue()
+		positionRepoModel, exist, err := server.PositionCache.GetWithRawValue()
 		if err != nil || !exist {
 			writer.WriteHeader(http.StatusInternalServerError)
-			log.Error("[statusHandler] failed to get position, exist: %v, err: %v", exist, errors.ErrorStack(err))
+			log.Error("[statusHandler] failed to get positionRepoModel, exist: %v, err: %v", exist, errors.ErrorStack(err))
 			return
 		}
 
 		var state = core.ReportStageIncremental
-		if position.Stage == config.Batch {
+		if positionRepoModel.Stage == string(config.Batch) {
 			state = core.ReportStageFull
-		}
-
-		s, ok := position.Value.(string)
-		if !ok {
-			log.Errorf("[statusHandler] invalid raw value type")
 		}
 
 		ret := core.TaskReportStatus{
 			Name:       name,
 			ConfigHash: hash,
-			Position:   s,
+			Position:   positionRepoModel.Value,
 			Stage:      state,
 			Version:    utils.Version,
 		}

--- a/cmd/gravity/main.go
+++ b/cmd/gravity/main.go
@@ -174,7 +174,7 @@ func healthzHandler(server *app.Server) func(http.ResponseWriter, *http.Request)
 
 func statusHandler(server *app.Server, name, hash string) func(http.ResponseWriter, *http.Request) {
 	return func(writer http.ResponseWriter, request *http.Request) {
-		position, v, exist, err := server.PositionCache.GetWithValueString()
+		position, v, exist, err := server.PositionCache.GetEncodedPersistentPosition()
 		if err != nil || !exist {
 			writer.WriteHeader(http.StatusInternalServerError)
 			log.Error("[statusHandler] failed to get positionRepoModel, exist: %v, err: %v", exist, errors.ErrorStack(err))

--- a/mock/position_store/mock.go
+++ b/mock/position_store/mock.go
@@ -82,9 +82,9 @@ func (mr *MockPositionCacheInterfaceMockRecorder) Get() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockPositionCacheInterface)(nil).Get))
 }
 
-// GetWithValueString mocks base method
-func (m *MockPositionCacheInterface) GetWithValueString() (position_store.PositionMeta, string, bool, error) {
-	ret := m.ctrl.Call(m, "GetWithValueString")
+// GetEncodedPersistentPosition mocks base method
+func (m *MockPositionCacheInterface) GetEncodedPersistentPosition() (position_store.PositionMeta, string, bool, error) {
+	ret := m.ctrl.Call(m, "GetEncodedPersistentPosition")
 	ret0, _ := ret[0].(position_store.PositionMeta)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(bool)
@@ -92,9 +92,9 @@ func (m *MockPositionCacheInterface) GetWithValueString() (position_store.Positi
 	return ret0, ret1, ret2, ret3
 }
 
-// GetWithValueString indicates an expected call of GetWithValueString
-func (mr *MockPositionCacheInterfaceMockRecorder) GetWithValueString() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWithValueString", reflect.TypeOf((*MockPositionCacheInterface)(nil).GetWithValueString))
+// GetEncodedPersistentPosition indicates an expected call of GetEncodedPersistentPosition
+func (mr *MockPositionCacheInterfaceMockRecorder) GetEncodedPersistentPosition() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEncodedPersistentPosition", reflect.TypeOf((*MockPositionCacheInterface)(nil).GetEncodedPersistentPosition))
 }
 
 // Put mocks base method

--- a/mock/position_store/mock.go
+++ b/mock/position_store/mock.go
@@ -82,6 +82,20 @@ func (mr *MockPositionCacheInterfaceMockRecorder) Get() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockPositionCacheInterface)(nil).Get))
 }
 
+// GetWithRawValue mocks base method
+func (m *MockPositionCacheInterface) GetWithRawValue() (position_store.Position, bool, error) {
+	ret := m.ctrl.Call(m, "GetWithRawValue")
+	ret0, _ := ret[0].(position_store.Position)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetWithRawValue indicates an expected call of GetWithRawValue
+func (mr *MockPositionCacheInterfaceMockRecorder) GetWithRawValue() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWithRawValue", reflect.TypeOf((*MockPositionCacheInterface)(nil).GetWithRawValue))
+}
+
 // Put mocks base method
 func (m *MockPositionCacheInterface) Put(arg0 position_store.Position) error {
 	ret := m.ctrl.Call(m, "Put", arg0)

--- a/mock/position_store/mock.go
+++ b/mock/position_store/mock.go
@@ -69,9 +69,9 @@ func (mr *MockPositionCacheInterfaceMockRecorder) Flush() *gomock.Call {
 }
 
 // Get mocks base method
-func (m *MockPositionCacheInterface) Get() (*position_store.Position, bool, error) {
+func (m *MockPositionCacheInterface) Get() (position_store.Position, bool, error) {
 	ret := m.ctrl.Call(m, "Get")
-	ret0, _ := ret[0].(*position_store.Position)
+	ret0, _ := ret[0].(position_store.Position)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -83,9 +83,9 @@ func (mr *MockPositionCacheInterfaceMockRecorder) Get() *gomock.Call {
 }
 
 // GetWithRawValue mocks base method
-func (m *MockPositionCacheInterface) GetWithRawValue() (*position_store.PositionRepoModel, bool, error) {
+func (m *MockPositionCacheInterface) GetWithRawValue() (*position_store.PositionWithValueString, bool, error) {
 	ret := m.ctrl.Call(m, "GetWithRawValue")
-	ret0, _ := ret[0].(*position_store.PositionRepoModel)
+	ret0, _ := ret[0].(*position_store.PositionWithValueString)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -97,7 +97,7 @@ func (mr *MockPositionCacheInterfaceMockRecorder) GetWithRawValue() *gomock.Call
 }
 
 // Put mocks base method
-func (m *MockPositionCacheInterface) Put(arg0 *position_store.Position) error {
+func (m *MockPositionCacheInterface) Put(arg0 position_store.Position) error {
 	ret := m.ctrl.Call(m, "Put", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/mock/position_store/mock.go
+++ b/mock/position_store/mock.go
@@ -83,12 +83,13 @@ func (mr *MockPositionCacheInterfaceMockRecorder) Get() *gomock.Call {
 }
 
 // GetWithValueString mocks base method
-func (m *MockPositionCacheInterface) GetWithValueString() (position_store.Position, bool, error) {
+func (m *MockPositionCacheInterface) GetWithValueString() (position_store.PositionMeta, string, bool, error) {
 	ret := m.ctrl.Call(m, "GetWithValueString")
-	ret0, _ := ret[0].(position_store.Position)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret0, _ := ret[0].(position_store.PositionMeta)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(bool)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
 }
 
 // GetWithValueString indicates an expected call of GetWithValueString

--- a/mock/position_store/mock.go
+++ b/mock/position_store/mock.go
@@ -82,18 +82,18 @@ func (mr *MockPositionCacheInterfaceMockRecorder) Get() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockPositionCacheInterface)(nil).Get))
 }
 
-// GetWithRawValue mocks base method
-func (m *MockPositionCacheInterface) GetWithRawValue() (*position_store.PositionWithValueString, bool, error) {
-	ret := m.ctrl.Call(m, "GetWithRawValue")
-	ret0, _ := ret[0].(*position_store.PositionWithValueString)
+// GetWithValueString mocks base method
+func (m *MockPositionCacheInterface) GetWithValueString() (position_store.Position, bool, error) {
+	ret := m.ctrl.Call(m, "GetWithValueString")
+	ret0, _ := ret[0].(position_store.Position)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// GetWithRawValue indicates an expected call of GetWithRawValue
-func (mr *MockPositionCacheInterfaceMockRecorder) GetWithRawValue() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWithRawValue", reflect.TypeOf((*MockPositionCacheInterface)(nil).GetWithRawValue))
+// GetWithValueString indicates an expected call of GetWithValueString
+func (mr *MockPositionCacheInterfaceMockRecorder) GetWithValueString() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWithValueString", reflect.TypeOf((*MockPositionCacheInterface)(nil).GetWithValueString))
 }
 
 // Put mocks base method

--- a/mock/position_store/mock.go
+++ b/mock/position_store/mock.go
@@ -69,9 +69,9 @@ func (mr *MockPositionCacheInterfaceMockRecorder) Flush() *gomock.Call {
 }
 
 // Get mocks base method
-func (m *MockPositionCacheInterface) Get() (position_store.Position, bool, error) {
+func (m *MockPositionCacheInterface) Get() (*position_store.Position, bool, error) {
 	ret := m.ctrl.Call(m, "Get")
-	ret0, _ := ret[0].(position_store.Position)
+	ret0, _ := ret[0].(*position_store.Position)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -83,9 +83,9 @@ func (mr *MockPositionCacheInterfaceMockRecorder) Get() *gomock.Call {
 }
 
 // GetWithRawValue mocks base method
-func (m *MockPositionCacheInterface) GetWithRawValue() (position_store.Position, bool, error) {
+func (m *MockPositionCacheInterface) GetWithRawValue() (*position_store.PositionRepoModel, bool, error) {
 	ret := m.ctrl.Call(m, "GetWithRawValue")
-	ret0, _ := ret[0].(position_store.Position)
+	ret0, _ := ret[0].(*position_store.PositionRepoModel)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -97,7 +97,7 @@ func (mr *MockPositionCacheInterfaceMockRecorder) GetWithRawValue() *gomock.Call
 }
 
 // Put mocks base method
-func (m *MockPositionCacheInterface) Put(arg0 position_store.Position) error {
+func (m *MockPositionCacheInterface) Put(arg0 *position_store.Position) error {
 	ret := m.ctrl.Call(m, "Put", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -97,6 +97,10 @@ type SourceProbeCfg struct {
 
 type MongoPosition bson.MongoTimestamp
 
+func (p MongoPosition) Empty() bool {
+	return p == 0
+}
+
 type MongoSource struct {
 	MongoConnConfig *MongoConnConfig `mapstructure:"source" toml:"source" json:"source"`
 	StartPosition   *MongoPosition   `mapstructure:"start-position" toml:"start-position" json:"start-position"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -97,10 +97,6 @@ type SourceProbeCfg struct {
 
 type MongoPosition bson.MongoTimestamp
 
-func (p MongoPosition) Empty() bool {
-	return p == 0
-}
-
 type MongoSource struct {
 	MongoConnConfig *MongoConnConfig `mapstructure:"source" toml:"source" json:"source"`
 	StartPosition   *MongoPosition   `mapstructure:"start-position" toml:"start-position" json:"start-position"`

--- a/pkg/inputs/helper/mysql_common.go
+++ b/pkg/inputs/helper/mysql_common.go
@@ -20,13 +20,16 @@ type BinlogPositionsValue struct {
 	StartPosition   *utils.MySQLBinlogPosition `json:"start_position"`
 }
 
-func SerializeBinlogPositionValue(position *BinlogPositionsValue) (string, error) {
-	s, err := myJson.MarshalToString(position)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
+func BinlogPositionValueEncoder(v interface{}) (string, error) {
+	return myJson.MarshalToString(v)
+}
 
-	return s, nil
+func BinlogPositionValueDecoder(s string) (interface{}, error) {
+	return DeserializeBinlogPositionValue(s)
+}
+
+func SerializeBinlogPositionValue(position *BinlogPositionsValue) (string, error) {
+	return BinlogPositionValueEncoder(position)
 }
 
 func DeserializeBinlogPositionValue(value string) (*BinlogPositionsValue, error) {

--- a/pkg/inputs/helper/mysql_common.go
+++ b/pkg/inputs/helper/mysql_common.go
@@ -16,8 +16,8 @@ type SourceProbeCfg struct {
 }
 
 type BinlogPositionsValue struct {
-	CurrentPosition utils.MySQLBinlogPosition `json:"current_position"`
-	StartPosition   utils.MySQLBinlogPosition `json:"start_position"`
+	CurrentPosition *utils.MySQLBinlogPosition `json:"current_position"`
+	StartPosition   *utils.MySQLBinlogPosition `json:"start_position"`
 }
 
 func BinlogPositionValueEncoder(v interface{}) (string, error) {

--- a/pkg/inputs/helper/mysql_common.go
+++ b/pkg/inputs/helper/mysql_common.go
@@ -16,8 +16,8 @@ type SourceProbeCfg struct {
 }
 
 type BinlogPositionsValue struct {
-	CurrentPosition *utils.MySQLBinlogPosition `json:"current_position"`
-	StartPosition   *utils.MySQLBinlogPosition `json:"start_position"`
+	CurrentPosition utils.MySQLBinlogPosition `json:"current_position"`
+	StartPosition   utils.MySQLBinlogPosition `json:"start_position"`
 }
 
 func BinlogPositionValueEncoder(v interface{}) (string, error) {
@@ -28,16 +28,16 @@ func BinlogPositionValueDecoder(s string) (interface{}, error) {
 	return DeserializeBinlogPositionValue(s)
 }
 
-func SerializeBinlogPositionValue(position *BinlogPositionsValue) (string, error) {
+func SerializeBinlogPositionValue(position BinlogPositionsValue) (string, error) {
 	return BinlogPositionValueEncoder(position)
 }
 
-func DeserializeBinlogPositionValue(value string) (*BinlogPositionsValue, error) {
+func DeserializeBinlogPositionValue(value string) (BinlogPositionsValue, error) {
 	position := BinlogPositionsValue{}
 	if err := myJson.UnmarshalFromString(value, &position); err != nil {
-		return nil, errors.Trace(err)
+		return BinlogPositionsValue{}, errors.Trace(err)
 	}
-	return &position, nil
+	return position, nil
 }
 
 func GetProbCfg(sourceProbeCfg *SourceProbeCfg, sourceDBCfg *utils.DBConfig) (*utils.DBConfig, string) {

--- a/pkg/inputs/helper/mysql_common_test.go
+++ b/pkg/inputs/helper/mysql_common_test.go
@@ -17,7 +17,7 @@ func TestSerializeBinlogPositions(t *testing.T) {
 		CurrentPosition: &utils.MySQLBinlogPosition{BinlogGTID: fmt.Sprintf("%s,%s", gtidBig, gtidSmall)},
 	}
 
-	v, err := SerializeBinlogPositionValue(&position)
+	v, err := SerializeBinlogPositionValue(position)
 	r.NoError(err)
 
 	p2, err := DeserializeBinlogPositionValue(v)

--- a/pkg/inputs/helper/two_stage_input.go
+++ b/pkg/inputs/helper/two_stage_input.go
@@ -126,9 +126,11 @@ func (i *TwoStageInputPlugin) Start(emitter core.Emitter, router core.Router, po
 				log.Fatalf("[TwoStageInputPlugin] failed to start incremental position store: %v", errors.ErrorStack(err))
 			}
 
-			i.positionCache.incremental.Put(pos)
+			if err := i.positionCache.incremental.Put(&pos); err != nil {
+				log.Fatalf("[TwoStageInputPlugin] failed to change incremental position")
+			}
 			if err := i.positionCache.incremental.Flush(); err != nil {
-				log.Fatalf("[TwoStageInputPlugin] failed to change position stage")
+				log.Fatalf("[TwoStageInputPlugin] failed to flush incremental position")
 			}
 
 			// start incremental plugin
@@ -228,7 +230,7 @@ func (s *twoStagePositionCache) Close() {
 	}
 }
 
-func (s *twoStagePositionCache) Put(position position_store.Position) error {
+func (s *twoStagePositionCache) Put(position *position_store.Position) error {
 	if s.Stage() == config.Stream {
 		return errors.Trace(s.incremental.Put(position))
 	} else {
@@ -236,7 +238,7 @@ func (s *twoStagePositionCache) Put(position position_store.Position) error {
 	}
 }
 
-func (s *twoStagePositionCache) Get() (position_store.Position, bool, error) {
+func (s *twoStagePositionCache) Get() (*position_store.Position, bool, error) {
 	if s.Stage() == config.Stream {
 		return s.incremental.Get()
 	} else {
@@ -244,7 +246,7 @@ func (s *twoStagePositionCache) Get() (position_store.Position, bool, error) {
 	}
 }
 
-func (s *twoStagePositionCache) GetWithRawValue() (position_store.Position, bool, error) {
+func (s *twoStagePositionCache) GetWithRawValue() (*position_store.PositionRepoModel, bool, error) {
 	if s.Stage() == config.Stream {
 		return s.incremental.GetWithRawValue()
 	} else {

--- a/pkg/inputs/helper/two_stage_input.go
+++ b/pkg/inputs/helper/two_stage_input.go
@@ -134,7 +134,7 @@ func (i *TwoStageInputPlugin) Start(emitter core.Emitter, router core.Router, po
 			// start incremental plugin
 			err = i.incremental.Start(emitter, router, positionCache)
 			if err != nil {
-				log.Fatalf("[TwoStageInputPlugin] fail to start incremental. %s", err)
+				log.Fatalf("[TwoStageInputPlugin] fail to start incremental. %s", errors.ErrorStack(err))
 			}
 			log.Infof("[TwoStageInputPlugin] incremental stage started")
 		}()
@@ -241,6 +241,14 @@ func (s *twoStagePositionCache) Get() (position_store.Position, bool, error) {
 		return s.incremental.Get()
 	} else {
 		return s.full.Get()
+	}
+}
+
+func (s *twoStagePositionCache) GetWithRawValue() (position_store.Position, bool, error) {
+	if s.Stage() == config.Stream {
+		return s.incremental.GetWithRawValue()
+	} else {
+		return s.full.GetWithRawValue()
 	}
 }
 

--- a/pkg/inputs/helper/two_stage_input.go
+++ b/pkg/inputs/helper/two_stage_input.go
@@ -246,7 +246,7 @@ func (s *twoStagePositionCache) Get() (position_store.Position, bool, error) {
 	}
 }
 
-func (s *twoStagePositionCache) GetWithValueString() (position_store.Position, bool, error) {
+func (s *twoStagePositionCache) GetWithValueString() (position_store.PositionMeta, string, bool, error) {
 	if s.Stage() == config.Stream {
 		return s.incremental.GetWithValueString()
 	} else {

--- a/pkg/inputs/helper/two_stage_input.go
+++ b/pkg/inputs/helper/two_stage_input.go
@@ -246,11 +246,11 @@ func (s *twoStagePositionCache) Get() (position_store.Position, bool, error) {
 	}
 }
 
-func (s *twoStagePositionCache) GetWithValueString() (position_store.PositionMeta, string, bool, error) {
+func (s *twoStagePositionCache) GetEncodedPersistentPosition() (position_store.PositionMeta, string, bool, error) {
 	if s.Stage() == config.Stream {
-		return s.incremental.GetWithValueString()
+		return s.incremental.GetEncodedPersistentPosition()
 	} else {
-		return s.full.GetWithValueString()
+		return s.full.GetEncodedPersistentPosition()
 	}
 }
 

--- a/pkg/inputs/helper/two_stage_input.go
+++ b/pkg/inputs/helper/two_stage_input.go
@@ -246,11 +246,11 @@ func (s *twoStagePositionCache) Get() (position_store.Position, bool, error) {
 	}
 }
 
-func (s *twoStagePositionCache) GetWithRawValue() (*position_store.PositionWithValueString, bool, error) {
+func (s *twoStagePositionCache) GetWithValueString() (position_store.Position, bool, error) {
 	if s.Stage() == config.Stream {
-		return s.incremental.GetWithRawValue()
+		return s.incremental.GetWithValueString()
 	} else {
-		return s.full.GetWithRawValue()
+		return s.full.GetWithValueString()
 	}
 }
 

--- a/pkg/inputs/helper/two_stage_input.go
+++ b/pkg/inputs/helper/two_stage_input.go
@@ -126,7 +126,7 @@ func (i *TwoStageInputPlugin) Start(emitter core.Emitter, router core.Router, po
 				log.Fatalf("[TwoStageInputPlugin] failed to start incremental position store: %v", errors.ErrorStack(err))
 			}
 
-			if err := i.positionCache.incremental.Put(&pos); err != nil {
+			if err := i.positionCache.incremental.Put(pos); err != nil {
 				log.Fatalf("[TwoStageInputPlugin] failed to change incremental position")
 			}
 			if err := i.positionCache.incremental.Flush(); err != nil {
@@ -230,7 +230,7 @@ func (s *twoStagePositionCache) Close() {
 	}
 }
 
-func (s *twoStagePositionCache) Put(position *position_store.Position) error {
+func (s *twoStagePositionCache) Put(position position_store.Position) error {
 	if s.Stage() == config.Stream {
 		return errors.Trace(s.incremental.Put(position))
 	} else {
@@ -238,7 +238,7 @@ func (s *twoStagePositionCache) Put(position *position_store.Position) error {
 	}
 }
 
-func (s *twoStagePositionCache) Get() (*position_store.Position, bool, error) {
+func (s *twoStagePositionCache) Get() (position_store.Position, bool, error) {
 	if s.Stage() == config.Stream {
 		return s.incremental.Get()
 	} else {
@@ -246,7 +246,7 @@ func (s *twoStagePositionCache) Get() (*position_store.Position, bool, error) {
 	}
 }
 
-func (s *twoStagePositionCache) GetWithRawValue() (*position_store.PositionRepoModel, bool, error) {
+func (s *twoStagePositionCache) GetWithRawValue() (*position_store.PositionWithValueString, bool, error) {
 	if s.Stage() == config.Stream {
 		return s.incremental.GetWithRawValue()
 	} else {

--- a/pkg/inputs/mongooplog/input.go
+++ b/pkg/inputs/mongooplog/input.go
@@ -19,7 +19,7 @@ import (
 type PluginConfig struct {
 	// MongoSource *config.MongoSource `mapstructure:"source" toml:"source" json:"source"`
 	Source        *config.MongoConnConfig `mapstructure:"source" toml:"source" json:"source"`
-	StartPosition config.MongoPosition    `mapstructure:"start-position" toml:"start-position" json:"start-position"`
+	StartPosition *config.MongoPosition   `mapstructure:"start-position" toml:"start-position" json:"start-position"`
 	GtmConfig     *config.GtmConfig       `mapstructure:"gtm-config" toml:"gtm-config" json:"gtm-config"`
 }
 

--- a/pkg/inputs/mongooplog/input.go
+++ b/pkg/inputs/mongooplog/input.go
@@ -69,6 +69,7 @@ func (plugin *mongoStreamInputPlugin) NewPositionCache() (position_store.Positio
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	positionRepo.SetEncoderDecoder(OplogPositionValueEncoder, OplogPositionValueDecoder)
 
 	positionCache, err := position_store.NewPositionCache(plugin.pipelineName, positionRepo, position_store.DefaultFlushPeriod)
 	if err != nil {

--- a/pkg/inputs/mongooplog/input.go
+++ b/pkg/inputs/mongooplog/input.go
@@ -19,7 +19,7 @@ import (
 type PluginConfig struct {
 	// MongoSource *config.MongoSource `mapstructure:"source" toml:"source" json:"source"`
 	Source        *config.MongoConnConfig `mapstructure:"source" toml:"source" json:"source"`
-	StartPosition *config.MongoPosition   `mapstructure:"start-position" toml:"start-position" json:"start-position"`
+	StartPosition config.MongoPosition    `mapstructure:"start-position" toml:"start-position" json:"start-position"`
 	GtmConfig     *config.GtmConfig       `mapstructure:"gtm-config" toml:"gtm-config" json:"gtm-config"`
 }
 

--- a/pkg/inputs/mongooplog/input.go
+++ b/pkg/inputs/mongooplog/input.go
@@ -144,7 +144,7 @@ func (plugin *mongoStreamInputPlugin) Done() chan position_store.Position {
 		plugin.Wait()
 		position, exist, err := plugin.positionCache.Get()
 		if err != nil && exist {
-			c <- *position
+			c <- position
 		} else {
 			log.Fatalf("[mongoStreamInputPlugin] failed to get position, exist: %v, err: %v", exist, errors.ErrorStack(err))
 		}

--- a/pkg/inputs/mongooplog/input.go
+++ b/pkg/inputs/mongooplog/input.go
@@ -69,9 +69,13 @@ func (plugin *mongoStreamInputPlugin) NewPositionCache() (position_store.Positio
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	positionRepo.SetEncoderDecoder(OplogPositionValueEncoder, OplogPositionValueDecoder)
 
-	positionCache, err := position_store.NewPositionCache(plugin.pipelineName, positionRepo, position_store.DefaultFlushPeriod)
+	positionCache, err := position_store.NewPositionCache(
+		plugin.pipelineName,
+		positionRepo,
+		OplogPositionValueEncoder,
+		OplogPositionValueDecoder,
+		position_store.DefaultFlushPeriod)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -140,7 +144,7 @@ func (plugin *mongoStreamInputPlugin) Done() chan position_store.Position {
 		plugin.Wait()
 		position, exist, err := plugin.positionCache.Get()
 		if err != nil && exist {
-			c <- position
+			c <- *position
 		} else {
 			log.Fatalf("[mongoStreamInputPlugin] failed to get position, exist: %v, err: %v", exist, errors.ErrorStack(err))
 		}

--- a/pkg/inputs/mongooplog/oplog_tailer.go
+++ b/pkg/inputs/mongooplog/oplog_tailer.go
@@ -112,11 +112,11 @@ func (tailer *OplogTailer) Run() {
 		if err != nil {
 			log.Fatalf("[oplogTailer] failed to get position: %v", errors.Trace(err))
 		}
-		return bson.MongoTimestamp(*positionValue.CurrentPosition)
+		return bson.MongoTimestamp(positionValue.CurrentPosition)
 	}
 
 	// If timestamp is 0, we start from the LastOpTimestamp
-	if *positionValue.CurrentPosition == 0 {
+	if positionValue.CurrentPosition.Empty() {
 		log.Infof("[oplog_tailer] start from the latest timestamp")
 		after = nil
 	} else {
@@ -224,7 +224,7 @@ func (tailer *OplogTailer) AfterMsgCommit(msg *core.Msg) error {
 		return errors.Errorf("invalid InputContext")
 	}
 
-	if err := UpdateCurrentPositionValue(tailer.positionCache, &position); err != nil {
+	if err := UpdateCurrentPositionValue(tailer.positionCache, position); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/pkg/inputs/mongooplog/oplog_tailer.go
+++ b/pkg/inputs/mongooplog/oplog_tailer.go
@@ -116,7 +116,7 @@ func (tailer *OplogTailer) Run() {
 	}
 
 	// If timestamp is 0, we start from the LastOpTimestamp
-	if positionValue.CurrentPosition.Empty() {
+	if positionValue.CurrentPosition == config.MongoPosition(0) {
 		log.Infof("[oplog_tailer] start from the latest timestamp")
 		after = nil
 	} else {

--- a/pkg/inputs/mongooplog/position_value.go
+++ b/pkg/inputs/mongooplog/position_value.go
@@ -58,7 +58,7 @@ func SetupInitialPosition(cache position_store.PositionCacheInterface, startPosi
 			UpdateTime: time.Now(),
 		}
 
-		if err := cache.Put(position); err != nil {
+		if err := cache.Put(&position); err != nil {
 			return errors.Trace(err)
 		}
 

--- a/pkg/inputs/mongooplog/position_value.go
+++ b/pkg/inputs/mongooplog/position_value.go
@@ -58,7 +58,7 @@ func SetupInitialPosition(cache position_store.PositionCacheInterface, startPosi
 			UpdateTime: time.Now(),
 		}
 
-		if err := cache.Put(&position); err != nil {
+		if err := cache.Put(position); err != nil {
 			return errors.Trace(err)
 		}
 

--- a/pkg/inputs/mongooplog/position_value.go
+++ b/pkg/inputs/mongooplog/position_value.go
@@ -53,9 +53,12 @@ func SetupInitialPosition(cache position_store.PositionCacheInterface, startPosi
 		}
 
 		position := position_store.Position{
-			Stage:      config.Stream,
-			Value:      positionValue,
-			UpdateTime: time.Now(),
+			PositionMeta: position_store.PositionMeta{
+				Stage:      config.Stream,
+				UpdateTime: time.Now(),
+			},
+
+			Value: positionValue,
 		}
 
 		if err := cache.Put(position); err != nil {

--- a/pkg/inputs/mongooplog/position_value_test.go
+++ b/pkg/inputs/mongooplog/position_value_test.go
@@ -27,7 +27,7 @@ func TestSetupInitialPosition(t *testing.T) {
 				1*time.Second)
 			r.NoError(err)
 
-			r.NoError(SetupInitialPosition(cache, config.MongoPosition(0)))
+			r.NoError(SetupInitialPosition(cache, nil))
 
 			position, exists, err := cache.Get()
 			r.NoError(err)
@@ -37,7 +37,7 @@ func TestSetupInitialPosition(t *testing.T) {
 
 			oplogPositionValue, ok := position.Value.(OplogPositionValue)
 			r.True(ok)
-			r.True(oplogPositionValue.StartPosition.Empty())
+			r.Nil(oplogPositionValue.StartPosition)
 			r.EqualValues(config.MongoPosition(0), oplogPositionValue.CurrentPosition)
 		})
 
@@ -54,7 +54,7 @@ func TestSetupInitialPosition(t *testing.T) {
 			r.NoError(err)
 
 			startSpec := config.MongoPosition(100)
-			r.NoError(SetupInitialPosition(cache, startSpec))
+			r.NoError(SetupInitialPosition(cache, &startSpec))
 
 			position, exists, err := cache.Get()
 			r.NoError(err)
@@ -62,7 +62,7 @@ func TestSetupInitialPosition(t *testing.T) {
 
 			oplogPositionValue, ok := position.Value.(OplogPositionValue)
 			r.True(ok)
-			r.EqualValues(config.MongoPosition(100), oplogPositionValue.StartPosition)
+			r.EqualValues(config.MongoPosition(100), *oplogPositionValue.StartPosition)
 			r.EqualValues(config.MongoPosition(100), oplogPositionValue.CurrentPosition)
 		})
 
@@ -84,7 +84,7 @@ func TestSetupInitialPosition(t *testing.T) {
 			r.NoError(err)
 
 			newStart := config.MongoPosition(400)
-			r.NoError(SetupInitialPosition(cache, newStart))
+			r.NoError(SetupInitialPosition(cache, &newStart))
 
 			position, exists, err := cache.Get()
 			r.NoError(err)
@@ -95,7 +95,7 @@ func TestSetupInitialPosition(t *testing.T) {
 			r.True(ok)
 
 			r.EqualValues(config.MongoPosition(400), oplogPositionValue.CurrentPosition)
-			r.EqualValues(config.MongoPosition(400), oplogPositionValue.StartPosition)
+			r.EqualValues(config.MongoPosition(400), *oplogPositionValue.StartPosition)
 		})
 
 		t.Run("when the start spec is the same with position in repo", func(ttt *testing.T) {
@@ -113,7 +113,7 @@ func TestSetupInitialPosition(t *testing.T) {
 			r.NoError(err)
 
 			newStart := config.MongoPosition(100)
-			r.NoError(SetupInitialPosition(cache, newStart))
+			r.NoError(SetupInitialPosition(cache, &newStart))
 
 			position, exists, err := cache.Get()
 			r.NoError(err)
@@ -123,8 +123,8 @@ func TestSetupInitialPosition(t *testing.T) {
 			oplogPositionValue, ok := position.Value.(OplogPositionValue)
 			r.True(ok)
 
+			r.EqualValues(config.MongoPosition(100), *oplogPositionValue.StartPosition)
 			r.EqualValues(config.MongoPosition(200), oplogPositionValue.CurrentPosition)
-			r.EqualValues(config.MongoPosition(100), oplogPositionValue.StartPosition)
 
 			// Test clear position
 			r.NoError(cache.Clear())
@@ -133,7 +133,7 @@ func TestSetupInitialPosition(t *testing.T) {
 			r.NoError(err)
 			r.False(exists)
 
-			r.NoError(SetupInitialPosition(cache, newStart))
+			r.NoError(SetupInitialPosition(cache, &newStart))
 			position, exists, err = cache.Get()
 			r.NoError(err)
 			r.True(exists)
@@ -142,7 +142,7 @@ func TestSetupInitialPosition(t *testing.T) {
 
 			oplogPositionValue, ok = position.Value.(OplogPositionValue)
 			r.True(ok)
-			r.EqualValues(newStart, oplogPositionValue.StartPosition)
+			r.EqualValues(newStart, *oplogPositionValue.StartPosition)
 
 		})
 
@@ -151,7 +151,7 @@ func TestSetupInitialPosition(t *testing.T) {
 
 func initPosition(repo position_store.PositionRepo, pipelineName string, start config.MongoPosition, current config.MongoPosition) error {
 	positionValue := OplogPositionValue{
-		StartPosition:   start,
+		StartPosition:   &start,
 		CurrentPosition: current,
 	}
 

--- a/pkg/inputs/mongooplog/position_value_test.go
+++ b/pkg/inputs/mongooplog/position_value_test.go
@@ -155,7 +155,7 @@ func initPosition(repo position_store.PositionRepo, pipelineName string, start c
 		CurrentPosition: current,
 	}
 
-	p := position_store.Position{
+	m := position_store.PositionMeta{
 		Name:  pipelineName,
 		Stage: config.Stream,
 	}
@@ -164,7 +164,6 @@ func initPosition(repo position_store.PositionRepo, pipelineName string, start c
 	if err != nil {
 		return errors.Trace(err)
 	}
-	p.ValueString = s
 
-	return errors.Trace(repo.Put(pipelineName, p))
+	return errors.Trace(repo.Put(pipelineName, m, s))
 }

--- a/pkg/inputs/mongooplog/position_value_test.go
+++ b/pkg/inputs/mongooplog/position_value_test.go
@@ -155,7 +155,7 @@ func initPosition(repo position_store.PositionRepo, pipelineName string, start *
 		CurrentPosition: current,
 	}
 
-	m := position_store.PositionRepoModel{
+	m := position_store.PositionWithValueString{
 		Name:  pipelineName,
 		Stage: string(config.Stream),
 	}

--- a/pkg/inputs/mysqlbatch/input.go
+++ b/pkg/inputs/mysqlbatch/input.go
@@ -321,18 +321,22 @@ func (plugin *mysqlBatchInputPlugin) waitFinish(positionCache position_store.Pos
 			log.Fatalf("[mysqlBatchInputPlugin] failed to get start streamPosition: %v", errors.ErrorStack(err))
 		}
 
+		currentPosition := startBinlog
 		binlogPositionsValue := helper.BinlogPositionsValue{
 			StartPosition:   &startBinlog,
-			CurrentPosition: &startBinlog,
+			CurrentPosition: &currentPosition,
 		}
 
 		// Notice that we should not change streamPosition stage in this plugin.
 		// Changing the stage is done by two stage plugin.
 		streamPosition := position_store.Position{
-			Name:       plugin.pipelineName,
-			Stage:      config.Stream,
-			Value:      binlogPositionsValue,
-			UpdateTime: time.Now(),
+			PositionMeta: position_store.PositionMeta{
+				Name:       plugin.pipelineName,
+				Stage:      config.Stream,
+				UpdateTime: time.Now(),
+			},
+
+			Value: binlogPositionsValue,
 		}
 
 		plugin.doneC <- streamPosition

--- a/pkg/inputs/mysqlbatch/input.go
+++ b/pkg/inputs/mysqlbatch/input.go
@@ -131,9 +131,12 @@ func (plugin *mysqlBatchInputPlugin) NewPositionCache() (position_store.Position
 		return nil, errors.Trace(err)
 	}
 
-	positionRepo.SetEncoderDecoder(EncodeBatchPositionValue, DecodeBatchPositionValue)
-
-	positionCache, err := position_store.NewPositionCache(plugin.pipelineName, positionRepo, position_store.DefaultFlushPeriod)
+	positionCache, err := position_store.NewPositionCache(
+		plugin.pipelineName,
+		positionRepo,
+		EncodeBatchPositionValue,
+		DecodeBatchPositionValue,
+		position_store.DefaultFlushPeriod)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/inputs/mysqlbatch/input.go
+++ b/pkg/inputs/mysqlbatch/input.go
@@ -322,8 +322,8 @@ func (plugin *mysqlBatchInputPlugin) waitFinish(positionCache position_store.Pos
 		}
 
 		binlogPositionsValue := helper.BinlogPositionsValue{
-			StartPosition:   startBinlog,
-			CurrentPosition: startBinlog,
+			StartPosition:   &startBinlog,
+			CurrentPosition: &startBinlog,
 		}
 
 		// Notice that we should not change streamPosition stage in this plugin.

--- a/pkg/inputs/mysqlbatch/input.go
+++ b/pkg/inputs/mysqlbatch/input.go
@@ -331,7 +331,7 @@ func (plugin *mysqlBatchInputPlugin) waitFinish(positionCache position_store.Pos
 		streamPosition := position_store.Position{
 			Name:       plugin.pipelineName,
 			Stage:      config.Stream,
-			Value:      &binlogPositionsValue,
+			Value:      binlogPositionsValue,
 			UpdateTime: time.Now(),
 		}
 
@@ -360,14 +360,14 @@ func InitTablePosition(db *sql.DB, positionCache position_store.PositionCacheInt
 		if scanColumn == "*" {
 			maxPos := TablePosition{Column: scanColumn, Type: PlainInt, Value: 1}
 			minPos := TablePosition{Column: scanColumn, Type: PlainInt, Value: 0}
-			if err := PutMaxMin(positionCache, fullTableName, &maxPos, &minPos); err != nil {
+			if err := PutMaxMin(positionCache, fullTableName, maxPos, minPos); err != nil {
 				return false, errors.Trace(err)
 			}
 		} else {
 			max, min := FindMaxMinValueFromDB(db, tableDef.Schema, tableDef.Name, scanColumn)
 			maxPos := TablePosition{Value: max, Type: scanType, Column: scanColumn}
 			minPos := TablePosition{Value: min, Type: scanType, Column: scanColumn}
-			if err := PutMaxMin(positionCache, fullTableName, &maxPos, &minPos); err != nil {
+			if err := PutMaxMin(positionCache, fullTableName, maxPos, minPos); err != nil {
 				return false, errors.Trace(err)
 			}
 			log.Infof("[InitTablePosition] table: %v, PutMaxMin: maxPos: %+v, minPos: %+v", fullTableName, maxPos, minPos)

--- a/pkg/inputs/mysqlbatch/mysql_table_scanner.go
+++ b/pkg/inputs/mysqlbatch/mysql_table_scanner.go
@@ -71,8 +71,8 @@ func (tableScanner *TableScanner) Start() error {
 					tableScanner.LoopInBatch(
 						tableScanner.db, work.TableDef,
 						work.TableConfig, scanColumn,
-						*max,
-						*min,
+						max,
+						min,
 						tableScanner.cfg.TableScanBatch)
 
 					if tableScanner.ctx.Err() == nil {
@@ -150,7 +150,7 @@ func (tableScanner *TableScanner) LoopInBatch(db *sql.DB, tableDef *schema_store
 	}
 
 	if !exists {
-		currentPosition = &min
+		currentPosition = min
 	} else {
 		if mysql.MySQLDataEquals(currentPosition.Value, max.Value) {
 			log.Infof("[LoopInBatch] already scanned: %v", utils.TableIdentity(tableDef.Schema, tableDef.Name))
@@ -316,15 +316,15 @@ func (tableScanner *TableScanner) FindAll(db *sql.DB, tableDef *schema_store.Tab
 	// set the current and max position to be the same
 	p := TablePosition{Column: "*", Type: PlainInt, Value: len(allData)}
 
-	if err := PutCurrentPos(tableScanner.positionCache, utils.TableIdentity(tableDef.Schema, tableDef.Name), &p, false); err != nil {
+	if err := PutCurrentPos(tableScanner.positionCache, utils.TableIdentity(tableDef.Schema, tableDef.Name), p, false); err != nil {
 		log.Fatalf("[FindAll] failed to put current pos: %v", errors.ErrorStack(err))
 	}
 
 	if err := PutMaxMin(
 		tableScanner.positionCache,
 		utils.TableIdentity(tableDef.Schema, tableDef.Name),
-		&p,
-		&TablePosition{Column: "*", Type: PlainInt, Value: 0}); err != nil {
+		p,
+		TablePosition{Column: "*", Type: PlainInt, Value: 0}); err != nil {
 		log.Fatalf("[FindAll] failed to put max min: %v", errors.ErrorStack(err))
 	}
 
@@ -347,7 +347,7 @@ func (tableScanner *TableScanner) AfterMsgCommit(msg *core.Msg) error {
 		return errors.Errorf("type invalid")
 	}
 
-	if err := PutCurrentPos(tableScanner.positionCache, *msg.InputStreamKey, &p, true); err != nil {
+	if err := PutCurrentPos(tableScanner.positionCache, *msg.InputStreamKey, p, true); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/pkg/inputs/mysqlbatch/mysql_table_scanner_test.go
+++ b/pkg/inputs/mysqlbatch/mysql_table_scanner_test.go
@@ -172,7 +172,6 @@ func TestTableScanner_Start(t *testing.T) {
 
 		dbCfg := mysql_test.SourceDBConfig()
 		positionRepo, err := position_store.NewMySQLRepo(dbCfg, "")
-		positionRepo.SetEncoderDecoder(EncodeBatchPositionValue, DecodeBatchPositionValue)
 		r.NoError(err)
 
 		testCases := []struct {
@@ -350,7 +349,12 @@ func TestTableScanner_Start(t *testing.T) {
 
 			throttle := time.NewTicker(100 * time.Millisecond)
 
-			positionCache, err := position_store.NewPositionCache(testDBName, positionRepo, 10*time.Second)
+			positionCache, err := position_store.NewPositionCache(
+				testDBName,
+				positionRepo,
+				EncodeBatchPositionValue,
+				DecodeBatchPositionValue,
+				10*time.Second)
 			r.NoError(err)
 
 			r.NoError(SetupInitialPosition(positionCache, db))
@@ -396,7 +400,12 @@ func TestTableScanner_Start(t *testing.T) {
 			em, err = emitter.NewEmitter(nil, submitter)
 			r.NoError(err)
 
-			positionCache, err = position_store.NewPositionCache(testDBName, positionRepo, 10*time.Second)
+			positionCache, err = position_store.NewPositionCache(
+				testDBName,
+				positionRepo,
+				EncodeBatchPositionValue,
+				DecodeBatchPositionValue,
+				10*time.Second)
 			r.NoError(err)
 
 			q = make(chan *TableWork, 1)

--- a/pkg/inputs/mysqlbatch/mysql_table_scanner_test.go
+++ b/pkg/inputs/mysqlbatch/mysql_table_scanner_test.go
@@ -172,6 +172,7 @@ func TestTableScanner_Start(t *testing.T) {
 
 		dbCfg := mysql_test.SourceDBConfig()
 		positionRepo, err := position_store.NewMySQLRepo(dbCfg, "")
+		positionRepo.SetEncoderDecoder(EncodeBatchPositionValue, DecodeBatchPositionValue)
 		r.NoError(err)
 
 		testCases := []struct {

--- a/pkg/inputs/mysqlbatch/mysql_table_scanner_test.go
+++ b/pkg/inputs/mysqlbatch/mysql_table_scanner_test.go
@@ -365,7 +365,8 @@ func TestTableScanner_Start(t *testing.T) {
 					tableDefs, tableConfigs = DeleteEmptyTables(db, tableDefs, tableConfigs)
 					r.Equal(0, len(tableDefs))
 				} else {
-					r.NoError(InitTablePosition(db, positionCache, tableDefs[i], c.scanColumn, 100))
+					_, err := InitTablePosition(db, positionCache, tableDefs[i], c.scanColumn, 100)
+					r.NoError(err)
 				}
 			}
 

--- a/pkg/inputs/mysqlbatch/position_value.go
+++ b/pkg/inputs/mysqlbatch/position_value.go
@@ -207,7 +207,7 @@ func SetupInitialPosition(cache position_store.PositionCacheInterface, sourceDB 
 		position.Value = &batchPositionValue
 		position.Stage = config.Batch
 		position.UpdateTime = time.Now()
-		if err := cache.Put(&position); err != nil {
+		if err := cache.Put(position); err != nil {
 			return errors.Trace(err)
 		}
 		if err := cache.Flush(); err != nil {

--- a/pkg/inputs/mysqlbatch/position_value.go
+++ b/pkg/inputs/mysqlbatch/position_value.go
@@ -181,7 +181,7 @@ func DecodeBatchPositionValue(s string) (interface{}, error) {
 }
 
 func SetupInitialPosition(cache position_store.PositionCacheInterface, sourceDB *sql.DB) error {
-	position, exist, err := cache.Get()
+	_, exist, err := cache.Get()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -203,11 +203,11 @@ func SetupInitialPosition(cache position_store.PositionCacheInterface, sourceDB 
 			Start:       &startPosition,
 			TableStates: make(map[string]TableStats),
 		}
-
+		position := position_store.Position{}
 		position.Value = &batchPositionValue
 		position.Stage = config.Batch
 		position.UpdateTime = time.Now()
-		if err := cache.Put(position); err != nil {
+		if err := cache.Put(&position); err != nil {
 			return errors.Trace(err)
 		}
 		if err := cache.Flush(); err != nil {

--- a/pkg/inputs/mysqlbatch/position_value_test.go
+++ b/pkg/inputs/mysqlbatch/position_value_test.go
@@ -52,7 +52,7 @@ func TestSetupInitialPosition(t *testing.T) {
 
 		s, err := EncodeBatchPositionValue(&batchPositionValue)
 		r.NoError(err)
-		r.NoError(repo.Put(pipelineName, position_store.Position{Name: pipelineName, Stage: config.Batch, ValueString: s}))
+		r.NoError(repo.Put(pipelineName, position_store.PositionMeta{Name: pipelineName, Stage: config.Batch}, s))
 
 		cache, err := position_store.NewPositionCache(
 			pipelineName,

--- a/pkg/inputs/mysqlbatch/position_value_test.go
+++ b/pkg/inputs/mysqlbatch/position_value_test.go
@@ -52,7 +52,7 @@ func TestSetupInitialPosition(t *testing.T) {
 
 		s, err := EncodeBatchPositionValue(&batchPositionValue)
 		r.NoError(err)
-		r.NoError(repo.Put(pipelineName, &position_store.PositionRepoModel{Name: pipelineName, Stage: string(config.Batch), Value: s}))
+		r.NoError(repo.Put(pipelineName, &position_store.PositionWithValueString{Name: pipelineName, Stage: string(config.Batch), Value: s}))
 
 		cache, err := position_store.NewPositionCache(
 			pipelineName,

--- a/pkg/inputs/mysqlbatch/position_value_test.go
+++ b/pkg/inputs/mysqlbatch/position_value_test.go
@@ -30,10 +30,11 @@ func TestSetupInitialPosition(t *testing.T) {
 		r.NoError(err)
 		r.True(exists)
 
-		positionValue, err := Deserialize(p.Value)
-		r.NoError(err)
-		r.NotNil(positionValue.Start)
-		r.NotEmpty(positionValue.Start.BinlogGTID)
+		batchPositionValue, ok := p.Value.(*BatchPositionValue)
+		r.True(ok)
+
+		r.NotNil(batchPositionValue.Start)
+		r.NotEmpty(batchPositionValue.Start.BinlogGTID)
 	})
 
 	t.Run("when position exists", func(tt *testing.T) {
@@ -44,10 +45,7 @@ func TestSetupInitialPosition(t *testing.T) {
 			Start: &utils.MySQLBinlogPosition{BinlogGTID: "abc:123"},
 		}
 
-		v, err := Serialize(&batchPositionValue)
-		r.NoError(err)
-
-		r.NoError(repo.Put(pipelineName, position_store.Position{Name: pipelineName, Stage: config.Batch, Value: v}))
+		r.NoError(repo.Put(pipelineName, position_store.Position{Name: pipelineName, Stage: config.Batch, Value: &batchPositionValue}))
 
 		cache, err := position_store.NewPositionCache(pipelineName, repo, 5*time.Second)
 		r.NoError(err)
@@ -60,13 +58,9 @@ func TestSetupInitialPosition(t *testing.T) {
 		r.NoError(err)
 		r.True(exists)
 
-		newPositionValue, err := Deserialize(p.Value)
-		r.NoError(err)
+		newPositionValue, ok := p.Value.(*BatchPositionValue)
+		r.True(ok)
 		r.Equal("abc:123", newPositionValue.Start.BinlogGTID)
 	})
-
-}
-
-func TestSerialize(t *testing.T) {
 
 }

--- a/pkg/inputs/mysqlbatch/position_value_test.go
+++ b/pkg/inputs/mysqlbatch/position_value_test.go
@@ -35,7 +35,7 @@ func TestSetupInitialPosition(t *testing.T) {
 		r.NoError(err)
 		r.True(exists)
 
-		batchPositionValue, ok := p.Value.(*BatchPositionValue)
+		batchPositionValue, ok := p.Value.(BatchPositionValue)
 		r.True(ok)
 
 		r.NotNil(batchPositionValue.Start)
@@ -47,12 +47,12 @@ func TestSetupInitialPosition(t *testing.T) {
 		pipelineName := utils.TestCaseMd5Name(tt)
 
 		batchPositionValue := BatchPositionValue{
-			Start: &utils.MySQLBinlogPosition{BinlogGTID: "abc:123"},
+			Start: utils.MySQLBinlogPosition{BinlogGTID: "abc:123"},
 		}
 
 		s, err := EncodeBatchPositionValue(&batchPositionValue)
 		r.NoError(err)
-		r.NoError(repo.Put(pipelineName, &position_store.PositionWithValueString{Name: pipelineName, Stage: string(config.Batch), Value: s}))
+		r.NoError(repo.Put(pipelineName, position_store.Position{Name: pipelineName, Stage: config.Batch, ValueString: s}))
 
 		cache, err := position_store.NewPositionCache(
 			pipelineName,
@@ -70,7 +70,7 @@ func TestSetupInitialPosition(t *testing.T) {
 		r.NoError(err)
 		r.True(exists)
 
-		newPositionValue, ok := p.Value.(*BatchPositionValue)
+		newPositionValue, ok := p.Value.(BatchPositionValue)
 		r.True(ok)
 		r.Equal("abc:123", newPositionValue.Start.BinlogGTID)
 	})

--- a/pkg/inputs/mysqlstream/binlog_tailer.go
+++ b/pkg/inputs/mysqlstream/binlog_tailer.go
@@ -157,12 +157,12 @@ func (tailer *BinlogTailer) Start() error {
 		return errors.Errorf("empty position")
 	}
 
-	binlogPositions, err := helper.DeserializeBinlogPositionValue(position.Value)
-	if err != nil {
-		return errors.Trace(err)
+	binlogPositionValue, ok := position.Value.(*helper.BinlogPositionsValue)
+	if !ok {
+		return errors.Errorf("invalid position type")
 	}
 
-	streamer, err := tailer.getBinlogStreamer(binlogPositions.CurrentPosition.BinlogGTID)
+	streamer, err := tailer.getBinlogStreamer(binlogPositionValue.CurrentPosition.BinlogGTID)
 
 	if err != nil {
 		return errors.Trace(err)

--- a/pkg/inputs/mysqlstream/binlog_tailer.go
+++ b/pkg/inputs/mysqlstream/binlog_tailer.go
@@ -157,7 +157,7 @@ func (tailer *BinlogTailer) Start() error {
 		return errors.Errorf("empty position")
 	}
 
-	binlogPositionValue, ok := position.Value.(*helper.BinlogPositionsValue)
+	binlogPositionValue, ok := position.Value.(helper.BinlogPositionsValue)
 	if !ok {
 		return errors.Errorf("invalid position type")
 	}
@@ -231,7 +231,7 @@ func (tailer *BinlogTailer) Start() error {
 					if err != nil {
 						log.Fatalf("[binlogTailer] failed getCurrentPosition, err: %v", errors.ErrorStack(err))
 					}
-					p, err := fixGTID(db, *currentPosition)
+					p, err := fixGTID(db, currentPosition)
 					if err != nil {
 						log.Fatalf("[binlogTailer] failed retrySyncGTIDs: %v", errors.ErrorStack(err))
 					}
@@ -466,7 +466,7 @@ func (tailer *BinlogTailer) Start() error {
 					ast,
 					ddlSQL,
 					int64(e.Header.Timestamp),
-					*currentPosition)
+					currentPosition)
 				if err := tailer.emitter.Emit(ddlMsg); err != nil {
 					log.Fatalf("failed to emit ddl msg: %v", errors.ErrorStack(err))
 				}
@@ -539,7 +539,7 @@ func (tailer *BinlogTailer) Start() error {
 				//  XID: 243
 				//  GTIDSet: 58ff439a-c2e2-11e6-bdc7-125c95d674c1:1-2225062
 				//
-				m := NewXIDMsg(int64(e.Header.Timestamp), tailer.AfterMsgCommit, *currentPosition)
+				m := NewXIDMsg(int64(e.Header.Timestamp), tailer.AfterMsgCommit, currentPosition)
 				if err != nil {
 					log.Fatalf("[binlogTailer] failed: %v", errors.ErrorStack(err))
 				}
@@ -557,7 +557,7 @@ func (tailer *BinlogTailer) AfterMsgCommit(msg *core.Msg) error {
 	ctx := msg.InputContext.(inputContext)
 	if ctx.op == xid || ctx.op == ddl {
 
-		if err := UpdateCurrentPositionValue(tailer.positionCache, &(ctx.position)); err != nil {
+		if err := UpdateCurrentPositionValue(tailer.positionCache, ctx.position); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/pkg/inputs/mysqlstream/binlog_tailer_test.go
+++ b/pkg/inputs/mysqlstream/binlog_tailer_test.go
@@ -113,13 +113,11 @@ func TestMsgEmit(t *testing.T) {
 			BinlogGTID:     gtidSet.String(),
 		},
 	}
-	v, err := helper.SerializeBinlogPositionValue(&positionValue)
-	assert.Nil(err)
 
 	p := position_store.Position{
 		Name:  "test",
 		Stage: config.Stream,
-		Value: v,
+		Value: &positionValue,
 	}
 	mockPositionCache := mock_position_store.NewMockPositionCacheInterface(mockCtrl)
 	mockPositionCache.EXPECT().Get().Return(p, true, nil).AnyTimes()

--- a/pkg/inputs/mysqlstream/binlog_tailer_test.go
+++ b/pkg/inputs/mysqlstream/binlog_tailer_test.go
@@ -115,8 +115,11 @@ func TestMsgEmit(t *testing.T) {
 	}
 
 	p := position_store.Position{
-		Name:  "test",
-		Stage: config.Stream,
+		PositionMeta: position_store.PositionMeta{
+			Name:  "test",
+			Stage: config.Stream,
+		},
+
 		Value: positionValue,
 	}
 	mockPositionCache := mock_position_store.NewMockPositionCacheInterface(mockCtrl)

--- a/pkg/inputs/mysqlstream/binlog_tailer_test.go
+++ b/pkg/inputs/mysqlstream/binlog_tailer_test.go
@@ -107,7 +107,7 @@ func TestMsgEmit(t *testing.T) {
 	r.NoError(err)
 
 	positionValue := helper.BinlogPositionsValue{
-		CurrentPosition: utils.MySQLBinlogPosition{
+		CurrentPosition: &utils.MySQLBinlogPosition{
 			BinLogFileName: position.Name,
 			BinLogFilePos:  position.Pos,
 			BinlogGTID:     gtidSet.String(),

--- a/pkg/inputs/mysqlstream/binlog_tailer_test.go
+++ b/pkg/inputs/mysqlstream/binlog_tailer_test.go
@@ -120,7 +120,7 @@ func TestMsgEmit(t *testing.T) {
 		Value: &positionValue,
 	}
 	mockPositionCache := mock_position_store.NewMockPositionCacheInterface(mockCtrl)
-	mockPositionCache.EXPECT().Get().Return(&p, true, nil).AnyTimes()
+	mockPositionCache.EXPECT().Get().Return(p, true, nil).AnyTimes()
 
 	// mockBinlogChecker
 	mockBinlogChecker := mock_binlog_checker.NewMockBinlogChecker(mockCtrl)

--- a/pkg/inputs/mysqlstream/binlog_tailer_test.go
+++ b/pkg/inputs/mysqlstream/binlog_tailer_test.go
@@ -120,7 +120,7 @@ func TestMsgEmit(t *testing.T) {
 		Value: &positionValue,
 	}
 	mockPositionCache := mock_position_store.NewMockPositionCacheInterface(mockCtrl)
-	mockPositionCache.EXPECT().Get().Return(p, true, nil).AnyTimes()
+	mockPositionCache.EXPECT().Get().Return(&p, true, nil).AnyTimes()
 
 	// mockBinlogChecker
 	mockBinlogChecker := mock_binlog_checker.NewMockBinlogChecker(mockCtrl)

--- a/pkg/inputs/mysqlstream/input.go
+++ b/pkg/inputs/mysqlstream/input.go
@@ -100,11 +100,12 @@ func (plugin *mysqlStreamInputPlugin) NewPositionCache() (position_store.Positio
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	positionRepo.SetEncoderDecoder(helper.BinlogPositionValueEncoder, helper.BinlogPositionValueDecoder)
 
 	positionCache, err := position_store.NewPositionCache(
 		plugin.pipelineName,
 		positionRepo,
+		helper.BinlogPositionValueEncoder,
+		helper.BinlogPositionValueDecoder,
 		position_store.DefaultFlushPeriod,
 	)
 	if err != nil {
@@ -199,7 +200,7 @@ func (plugin *mysqlStreamInputPlugin) Done() chan position_store.Position {
 		plugin.binlogTailer.Wait()
 		position, exist, err := plugin.positionCache.Get()
 		if err == nil && exist {
-			c <- position
+			c <- *position
 		} else {
 			log.Fatalf("[mysqlInputPlugin] failed get position exist: %v, err: %v", exist, errors.ErrorStack(err))
 		}

--- a/pkg/inputs/mysqlstream/input.go
+++ b/pkg/inputs/mysqlstream/input.go
@@ -33,9 +33,9 @@ var (
 const inputStreamKey = "mysqlstream"
 
 type MySQLBinlogInputPluginConfig struct {
-	Source                  *utils.DBConfig           `mapstructure:"source" toml:"source" json:"source"`
-	IgnoreBiDirectionalData bool                      `mapstructure:"ignore-bidirectional-data" toml:"ignore-bidirectional-data" json:"ignore-bidirectional-data"`
-	StartPosition           utils.MySQLBinlogPosition `mapstructure:"start-position" toml:"start-position" json:"start-position"`
+	Source                  *utils.DBConfig            `mapstructure:"source" toml:"source" json:"source"`
+	IgnoreBiDirectionalData bool                       `mapstructure:"ignore-bidirectional-data" toml:"ignore-bidirectional-data" json:"ignore-bidirectional-data"`
+	StartPosition           *utils.MySQLBinlogPosition `mapstructure:"start-position" toml:"start-position" json:"start-position"`
 
 	SourceProbeCfg *helper.SourceProbeCfg `mapstructure:"source-probe-config"json:"source-probe-config"`
 

--- a/pkg/inputs/mysqlstream/input.go
+++ b/pkg/inputs/mysqlstream/input.go
@@ -200,7 +200,7 @@ func (plugin *mysqlStreamInputPlugin) Done() chan position_store.Position {
 		plugin.binlogTailer.Wait()
 		position, exist, err := plugin.positionCache.Get()
 		if err == nil && exist {
-			c <- *position
+			c <- position
 		} else {
 			log.Fatalf("[mysqlInputPlugin] failed get position exist: %v, err: %v", exist, errors.ErrorStack(err))
 		}

--- a/pkg/inputs/mysqlstream/input.go
+++ b/pkg/inputs/mysqlstream/input.go
@@ -33,9 +33,9 @@ var (
 const inputStreamKey = "mysqlstream"
 
 type MySQLBinlogInputPluginConfig struct {
-	Source                  *utils.DBConfig            `mapstructure:"source" toml:"source" json:"source"`
-	IgnoreBiDirectionalData bool                       `mapstructure:"ignore-bidirectional-data" toml:"ignore-bidirectional-data" json:"ignore-bidirectional-data"`
-	StartPosition           *utils.MySQLBinlogPosition `mapstructure:"start-position" toml:"start-position" json:"start-position"`
+	Source                  *utils.DBConfig           `mapstructure:"source" toml:"source" json:"source"`
+	IgnoreBiDirectionalData bool                      `mapstructure:"ignore-bidirectional-data" toml:"ignore-bidirectional-data" json:"ignore-bidirectional-data"`
+	StartPosition           utils.MySQLBinlogPosition `mapstructure:"start-position" toml:"start-position" json:"start-position"`
 
 	SourceProbeCfg *helper.SourceProbeCfg `mapstructure:"source-probe-config"json:"source-probe-config"`
 

--- a/pkg/inputs/mysqlstream/input.go
+++ b/pkg/inputs/mysqlstream/input.go
@@ -100,6 +100,7 @@ func (plugin *mysqlStreamInputPlugin) NewPositionCache() (position_store.Positio
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	positionRepo.SetEncoderDecoder(helper.BinlogPositionValueEncoder, helper.BinlogPositionValueDecoder)
 
 	positionCache, err := position_store.NewPositionCache(
 		plugin.pipelineName,

--- a/pkg/inputs/mysqlstream/position_value.go
+++ b/pkg/inputs/mysqlstream/position_value.go
@@ -32,18 +32,13 @@ func SetupInitialPosition(db *sql.DB, positionCache position_store.PositionCache
 		}
 		// Do not initialize start position.
 		// StartPosition is a user configured parameter.
-		binlogPositions := helper.BinlogPositionsValue{
+		binlogPositionValue := helper.BinlogPositionsValue{
 			CurrentPosition: p,
-		}
-
-		v, err := helper.SerializeBinlogPositionValue(&binlogPositions)
-		if err != nil {
-			return errors.Trace(err)
 		}
 
 		position := position_store.Position{
 			Stage:      config.Stream,
-			Value:      v,
+			Value:      &binlogPositionValue,
 			UpdateTime: time.Now(),
 		}
 		if err := positionCache.Put(position); err != nil {
@@ -54,9 +49,9 @@ func SetupInitialPosition(db *sql.DB, positionCache position_store.PositionCache
 
 	}
 
-	runTimePositions, err := helper.DeserializeBinlogPositionValue(position.Value)
-	if err != nil {
-		return errors.Trace(err)
+	runTimePositions, ok := position.Value.(*helper.BinlogPositionsValue)
+	if !ok {
+		return errors.Errorf("invalid position value type")
 	}
 
 	// reset runTimePositions
@@ -72,11 +67,7 @@ func SetupInitialPosition(db *sql.DB, positionCache position_store.PositionCache
 		}
 	}
 
-	v, err := helper.SerializeBinlogPositionValue(runTimePositions)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	position.Value = v
+	position.Value = runTimePositions
 	if err := positionCache.Put(position); err != nil {
 		return errors.Trace(err)
 	}
@@ -97,14 +88,14 @@ func UpdateCurrentPositionValue(cache position_store.PositionCacheInterface, cur
 		return errors.Trace(err)
 	}
 
-	v, err := helper.SerializeBinlogPositionValue(&helper.BinlogPositionsValue{StartPosition: start, CurrentPosition: currentPosition})
-	if err != nil {
-		return errors.Trace(err)
+	binlogPositionValue := helper.BinlogPositionsValue{
+		StartPosition:   start,
+		CurrentPosition: currentPosition,
 	}
 
 	position := position_store.Position{
 		Stage: config.Stream,
-		Value: v,
+		Value: &binlogPositionValue,
 	}
 
 	if err := cache.Put(position); err != nil {
@@ -133,14 +124,14 @@ func getBinlogPositionsValue(cache position_store.PositionCacheInterface) (*util
 		return nil, nil, errors.New("empty position")
 	}
 
-	positions, err := helper.DeserializeBinlogPositionValue(position.Value)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
+	binlogPositionValue, ok := position.Value.(*helper.BinlogPositionsValue)
+	if !ok {
+		return nil, nil, errors.Errorf("invalid position type")
 	}
 
-	if positions.CurrentPosition == nil {
+	if binlogPositionValue.CurrentPosition == nil {
 		return nil, nil, errors.Errorf("empty currentPosition")
 	}
 
-	return positions.StartPosition, positions.CurrentPosition, nil
+	return binlogPositionValue.StartPosition, binlogPositionValue.CurrentPosition, nil
 }

--- a/pkg/inputs/mysqlstream/position_value.go
+++ b/pkg/inputs/mysqlstream/position_value.go
@@ -12,7 +12,7 @@ import (
 	gomysql "github.com/siddontang/go-mysql/mysql"
 )
 
-func SetupInitialPosition(db *sql.DB, positionCache position_store.PositionCacheInterface, startPositionSpec *utils.MySQLBinlogPosition) error {
+func SetupInitialPosition(db *sql.DB, positionCache position_store.PositionCacheInterface, startPositionSpec utils.MySQLBinlogPosition) error {
 	position, exist, err := positionCache.Get()
 	if err != nil {
 		return errors.Trace(err)
@@ -25,7 +25,7 @@ func SetupInitialPosition(db *sql.DB, positionCache position_store.PositionCache
 			return errors.Trace(err)
 		}
 
-		p := &utils.MySQLBinlogPosition{
+		p := utils.MySQLBinlogPosition{
 			BinLogFileName: binlogFilePos.Name,
 			BinLogFilePos:  binlogFilePos.Pos,
 			BinlogGTID:     gtid.String(),
@@ -38,7 +38,7 @@ func SetupInitialPosition(db *sql.DB, positionCache position_store.PositionCache
 
 		position := position_store.Position{
 			Stage:      config.Stream,
-			Value:      &binlogPositionValue,
+			Value:      binlogPositionValue,
 			UpdateTime: time.Now(),
 		}
 		if err := positionCache.Put(position); err != nil {
@@ -49,14 +49,14 @@ func SetupInitialPosition(db *sql.DB, positionCache position_store.PositionCache
 
 	}
 
-	runTimePositions, ok := position.Value.(*helper.BinlogPositionsValue)
+	runTimePositions, ok := position.Value.(helper.BinlogPositionsValue)
 	if !ok {
 		return errors.Errorf("invalid position value type")
 	}
 
 	// reset runTimePositions
-	if startPositionSpec != nil {
-		if runTimePositions.StartPosition == nil {
+	if !startPositionSpec.Empty() {
+		if runTimePositions.StartPosition.Empty() {
 			runTimePositions.StartPosition = startPositionSpec
 			runTimePositions.CurrentPosition = startPositionSpec
 		} else {
@@ -74,15 +74,15 @@ func SetupInitialPosition(db *sql.DB, positionCache position_store.PositionCache
 	return errors.Trace(positionCache.Flush())
 }
 
-func GetCurrentPositionValue(cache position_store.PositionCacheInterface) (*utils.MySQLBinlogPosition, error) {
+func GetCurrentPositionValue(cache position_store.PositionCacheInterface) (utils.MySQLBinlogPosition, error) {
 	_, current, err := getBinlogPositionsValue(cache)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return utils.MySQLBinlogPosition{}, errors.Trace(err)
 	}
 	return current, nil
 }
 
-func UpdateCurrentPositionValue(cache position_store.PositionCacheInterface, currentPosition *utils.MySQLBinlogPosition) error {
+func UpdateCurrentPositionValue(cache position_store.PositionCacheInterface, currentPosition utils.MySQLBinlogPosition) error {
 	start, _, err := getBinlogPositionsValue(cache)
 	if err != nil {
 		return errors.Trace(err)
@@ -95,7 +95,7 @@ func UpdateCurrentPositionValue(cache position_store.PositionCacheInterface, cur
 
 	position := position_store.Position{
 		Stage: config.Stream,
-		Value: &binlogPositionValue,
+		Value: binlogPositionValue,
 	}
 
 	if err := cache.Put(position); err != nil {
@@ -114,23 +114,23 @@ func ToGoMySQLPosition(p utils.MySQLBinlogPosition) (gomysql.Position, gomysql.M
 	return gomysql.Position{Name: p.BinLogFileName, Pos: p.BinLogFilePos}, mysqlGTIDSet, nil
 }
 
-func getBinlogPositionsValue(cache position_store.PositionCacheInterface) (*utils.MySQLBinlogPosition, *utils.MySQLBinlogPosition, error) {
+func getBinlogPositionsValue(cache position_store.PositionCacheInterface) (utils.MySQLBinlogPosition, utils.MySQLBinlogPosition, error) {
 	position, exist, err := cache.Get()
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return utils.MySQLBinlogPosition{}, utils.MySQLBinlogPosition{}, errors.Trace(err)
 	}
 
 	if !exist {
-		return nil, nil, errors.New("empty position")
+		return utils.MySQLBinlogPosition{}, utils.MySQLBinlogPosition{}, errors.New("empty position")
 	}
 
-	binlogPositionValue, ok := position.Value.(*helper.BinlogPositionsValue)
+	binlogPositionValue, ok := position.Value.(helper.BinlogPositionsValue)
 	if !ok {
-		return nil, nil, errors.Errorf("invalid position type")
+		return utils.MySQLBinlogPosition{}, utils.MySQLBinlogPosition{}, errors.Errorf("invalid position type")
 	}
 
-	if binlogPositionValue.CurrentPosition == nil {
-		return nil, nil, errors.Errorf("empty currentPosition")
+	if binlogPositionValue.CurrentPosition.Empty() {
+		return utils.MySQLBinlogPosition{}, utils.MySQLBinlogPosition{}, errors.Errorf("empty currentPosition")
 	}
 
 	return binlogPositionValue.StartPosition, binlogPositionValue.CurrentPosition, nil

--- a/pkg/inputs/mysqlstream/position_value.go
+++ b/pkg/inputs/mysqlstream/position_value.go
@@ -41,7 +41,7 @@ func SetupInitialPosition(db *sql.DB, positionCache position_store.PositionCache
 			Value:      &binlogPositionValue,
 			UpdateTime: time.Now(),
 		}
-		if err := positionCache.Put(position); err != nil {
+		if err := positionCache.Put(&position); err != nil {
 			return errors.Trace(err)
 		}
 
@@ -98,7 +98,7 @@ func UpdateCurrentPositionValue(cache position_store.PositionCacheInterface, cur
 		Value: &binlogPositionValue,
 	}
 
-	if err := cache.Put(position); err != nil {
+	if err := cache.Put(&position); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/pkg/inputs/mysqlstream/position_value.go
+++ b/pkg/inputs/mysqlstream/position_value.go
@@ -37,9 +37,12 @@ func SetupInitialPosition(db *sql.DB, positionCache position_store.PositionCache
 		}
 
 		position := position_store.Position{
-			Stage:      config.Stream,
-			Value:      binlogPositionValue,
-			UpdateTime: time.Now(),
+			PositionMeta: position_store.PositionMeta{
+				Stage:      config.Stream,
+				UpdateTime: time.Now(),
+			},
+
+			Value: binlogPositionValue,
 		}
 		if err := positionCache.Put(position); err != nil {
 			return errors.Trace(err)
@@ -94,7 +97,10 @@ func UpdateCurrentPositionValue(cache position_store.PositionCacheInterface, cur
 	}
 
 	position := position_store.Position{
-		Stage: config.Stream,
+		PositionMeta: position_store.PositionMeta{
+			Stage: config.Stream,
+		},
+
 		Value: binlogPositionValue,
 	}
 

--- a/pkg/inputs/mysqlstream/position_value.go
+++ b/pkg/inputs/mysqlstream/position_value.go
@@ -41,7 +41,7 @@ func SetupInitialPosition(db *sql.DB, positionCache position_store.PositionCache
 			Value:      &binlogPositionValue,
 			UpdateTime: time.Now(),
 		}
-		if err := positionCache.Put(&position); err != nil {
+		if err := positionCache.Put(position); err != nil {
 			return errors.Trace(err)
 		}
 
@@ -98,7 +98,7 @@ func UpdateCurrentPositionValue(cache position_store.PositionCacheInterface, cur
 		Value: &binlogPositionValue,
 	}
 
-	if err := cache.Put(&position); err != nil {
+	if err := cache.Put(position); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/pkg/inputs/mysqlstream/position_value_test.go
+++ b/pkg/inputs/mysqlstream/position_value_test.go
@@ -20,7 +20,7 @@ func initRepo(repo position_store.PositionRepo, pipelineName string, startGTID s
 		StartPosition:   &utils.MySQLBinlogPosition{BinlogGTID: startGTID},
 	}
 
-	m := position_store.Position{
+	m := position_store.PositionMeta{
 		Name:  pipelineName,
 		Stage: config.Stream,
 	}
@@ -29,9 +29,7 @@ func initRepo(repo position_store.PositionRepo, pipelineName string, startGTID s
 	if err != nil {
 		return errors.Trace(err)
 	}
-	m.ValueString = s
-
-	return errors.Trace(repo.Put(pipelineName, m))
+	return errors.Trace(repo.Put(pipelineName, m, s))
 }
 
 func TestSetupInitialPosition(t *testing.T) {

--- a/pkg/inputs/mysqlstream/position_value_test.go
+++ b/pkg/inputs/mysqlstream/position_value_test.go
@@ -16,8 +16,8 @@ import (
 func initRepo(repo position_store.PositionRepo, pipelineName string, startGTID string, currentGTID string) error {
 
 	positionValue := &helper.BinlogPositionsValue{
-		CurrentPosition: utils.MySQLBinlogPosition{BinlogGTID: currentGTID},
-		StartPosition:   utils.MySQLBinlogPosition{BinlogGTID: startGTID},
+		CurrentPosition: &utils.MySQLBinlogPosition{BinlogGTID: currentGTID},
+		StartPosition:   &utils.MySQLBinlogPosition{BinlogGTID: startGTID},
 	}
 
 	m := position_store.Position{
@@ -51,7 +51,7 @@ func TestSetupInitialPosition(t *testing.T) {
 			r.NoError(err)
 
 			db := mysql_test.MustSetupSourceDB(utils.TestCaseMd5Name(ttt))
-			err = SetupInitialPosition(db, cache, utils.MySQLBinlogPosition{})
+			err = SetupInitialPosition(db, cache, nil)
 			r.NoError(err)
 
 			// it should init the current position to current master's position, and
@@ -62,8 +62,8 @@ func TestSetupInitialPosition(t *testing.T) {
 
 			positionValue, ok := position.Value.(helper.BinlogPositionsValue)
 			r.True(ok)
-			r.True(positionValue.StartPosition.Empty())
-			r.False(positionValue.CurrentPosition.Empty())
+			r.Nil(positionValue.StartPosition)
+			r.NotNil(positionValue.CurrentPosition)
 		})
 
 		tt.Run("when start spec is not nil", func(ttt *testing.T) {
@@ -90,7 +90,7 @@ func TestSetupInitialPosition(t *testing.T) {
 				BinlogGTID: newGTID,
 			}
 
-			err = SetupInitialPosition(db, cache, specStart)
+			err = SetupInitialPosition(db, cache, &specStart)
 			r.NoError(err)
 
 			p, exists, err := cache.Get()
@@ -123,7 +123,7 @@ func TestSetupInitialPosition(t *testing.T) {
 				helper.BinlogPositionValueDecoder,
 				5*time.Second)
 			r.NoError(err)
-			r.NoError(SetupInitialPosition(db, cache, specStart))
+			r.NoError(SetupInitialPosition(db, cache, &specStart))
 
 			p, exists, err := cache.Get()
 			r.NoError(err)
@@ -154,7 +154,7 @@ func TestSetupInitialPosition(t *testing.T) {
 				helper.BinlogPositionValueDecoder,
 				5*time.Second)
 			r.NoError(err)
-			r.NoError(SetupInitialPosition(db, cache, specStart))
+			r.NoError(SetupInitialPosition(db, cache, &specStart))
 
 			p, exists, err := cache.Get()
 			r.NoError(err)

--- a/pkg/inputs/mysqlstream/position_value_test.go
+++ b/pkg/inputs/mysqlstream/position_value_test.go
@@ -20,7 +20,7 @@ func initRepo(repo position_store.PositionRepo, pipelineName string, startGTID s
 		StartPosition:   &utils.MySQLBinlogPosition{BinlogGTID: startGTID},
 	}
 
-	m := position_store.PositionRepoModel{
+	m := position_store.PositionWithValueString{
 		Name:  pipelineName,
 		Stage: string(config.Stream),
 	}

--- a/pkg/inputs/tidb_kafka/input.go
+++ b/pkg/inputs/tidb_kafka/input.go
@@ -143,7 +143,7 @@ func (plugin *tidbKafkaStreamInputPlugin) Done() chan position_store.Position {
 		plugin.binlogTailer.Wait()
 		position, exist, err := plugin.positionCache.Get()
 		if err != nil && exist {
-			c <- *position
+			c <- position
 		} else {
 			log.Fatalf("[tidbKafkaStreamInputPlugin] failed to get position, exist: %v, err: %v", exist, errors.ErrorStack(err))
 		}

--- a/pkg/inputs/tidb_kafka/input.go
+++ b/pkg/inputs/tidb_kafka/input.go
@@ -78,6 +78,8 @@ func (plugin *tidbKafkaStreamInputPlugin) NewPositionCache() (position_store.Pos
 		return nil, errors.Trace(err)
 	}
 
+	positionRepo.SetEncoderDecoder(KafkaPositionValueEncoder, KafkaPositionValueDecoder)
+
 	positionCache, err := position_store.NewPositionCache(plugin.pipelineName, positionRepo, position_store.DefaultFlushPeriod)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/pkg/inputs/tidb_kafka/input.go
+++ b/pkg/inputs/tidb_kafka/input.go
@@ -78,9 +78,12 @@ func (plugin *tidbKafkaStreamInputPlugin) NewPositionCache() (position_store.Pos
 		return nil, errors.Trace(err)
 	}
 
-	positionRepo.SetEncoderDecoder(KafkaPositionValueEncoder, KafkaPositionValueDecoder)
-
-	positionCache, err := position_store.NewPositionCache(plugin.pipelineName, positionRepo, position_store.DefaultFlushPeriod)
+	positionCache, err := position_store.NewPositionCache(
+		plugin.pipelineName,
+		positionRepo,
+		KafkaPositionValueEncoder,
+		KafkaPositionValueDecoder,
+		position_store.DefaultFlushPeriod)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -140,7 +143,7 @@ func (plugin *tidbKafkaStreamInputPlugin) Done() chan position_store.Position {
 		plugin.binlogTailer.Wait()
 		position, exist, err := plugin.positionCache.Get()
 		if err != nil && exist {
-			c <- position
+			c <- *position
 		} else {
 			log.Fatalf("[tidbKafkaStreamInputPlugin] failed to get position, exist: %v, err: %v", exist, errors.ErrorStack(err))
 		}

--- a/pkg/position_store/cache.go
+++ b/pkg/position_store/cache.go
@@ -19,9 +19,7 @@ type PositionCacheInterface interface {
 	// it will try to get it from position repo
 	Get() (position Position, exist bool, err error)
 
-	// GetWithValueString will serialize the Value to ValueString, if there is no value inside the cache
-	// it will try to get it from position repo
-	GetWithValueString() (position PositionMeta, v string, exist bool, err error)
+	GetEncodedPersistentPosition() (position PositionMeta, v string, exist bool, err error)
 	Flush() error
 	Clear() error
 }
@@ -138,7 +136,7 @@ func (cache *defaultPositionCache) Get() (Position, bool, error) {
 	return cache.position, true, nil
 }
 
-func (cache *defaultPositionCache) GetWithValueString() (PositionMeta, string, bool, error) {
+func (cache *defaultPositionCache) GetEncodedPersistentPosition() (PositionMeta, string, bool, error) {
 	cache.positionMutex.Lock()
 	defer cache.positionMutex.Unlock()
 

--- a/pkg/position_store/cache_test.go
+++ b/pkg/position_store/cache_test.go
@@ -24,7 +24,7 @@ func TestPositionCache_New(t *testing.T) {
 
 	t.Run("when repo has some data", func(tt *testing.T) {
 		repo := NewMemoRepo()
-		err := repo.Put(t.Name(), &PositionRepoModel{Value: "test", Stage: string(config.Stream)})
+		err := repo.Put(t.Name(), &PositionWithValueString{Value: "test", Stage: string(config.Stream)})
 		r.NoError(err)
 
 		cache, err := NewPositionCache(t.Name(), repo, StringEncoder, StringDecoder, DefaultFlushPeriod)

--- a/pkg/position_store/cache_test.go
+++ b/pkg/position_store/cache_test.go
@@ -13,6 +13,7 @@ func TestPositionCache_New(t *testing.T) {
 
 	t.Run("when repo dont have any data", func(tt *testing.T) {
 		repo := NewMemoRepo()
+		repo.SetEncoderDecoder(StringEncoder, StringDecoder)
 		cache, err := NewPositionCache(t.Name(), repo, DefaultFlushPeriod)
 		r.NoError(err)
 
@@ -23,6 +24,7 @@ func TestPositionCache_New(t *testing.T) {
 
 	t.Run("when repo has some data", func(tt *testing.T) {
 		repo := NewMemoRepo()
+		repo.SetEncoderDecoder(StringEncoder, StringDecoder)
 		err := repo.Put(t.Name(), Position{Value: "test", Stage: config.Stream})
 		r.NoError(err)
 
@@ -43,7 +45,7 @@ func TestPositionCache_GetPut(t *testing.T) {
 
 	t.Run("when position is not valid", func(tt *testing.T) {
 		repo := NewMemoRepo()
-
+		repo.SetEncoderDecoder(StringEncoder, StringDecoder)
 		cache, err := NewPositionCache(t.Name(), repo, DefaultFlushPeriod)
 		r.NoError(err)
 
@@ -57,7 +59,7 @@ func TestPositionCache_GetPut(t *testing.T) {
 
 	t.Run("when position is valid", func(tt *testing.T) {
 		repo := NewMemoRepo()
-
+		repo.SetEncoderDecoder(StringEncoder, StringDecoder)
 		cache, err := NewPositionCache(t.Name(), repo, DefaultFlushPeriod)
 		r.NoError(err)
 
@@ -84,6 +86,8 @@ func TestDefaultPositionCache_Flush(t *testing.T) {
 
 	t.Run("it does not flush when time has not come", func(tt *testing.T) {
 		repo := NewMemoRepo()
+		repo.SetEncoderDecoder(StringEncoder, StringDecoder)
+
 		cache, err := NewPositionCache(t.Name(), repo, 5*time.Second)
 		r.NoError(err)
 
@@ -119,6 +123,8 @@ func TestDefaultPositionCache_Flush(t *testing.T) {
 
 	t.Run("it flush to repo when time comes", func(tt *testing.T) {
 		repo := NewMemoRepo()
+		repo.SetEncoderDecoder(StringEncoder, StringDecoder)
+
 		cache, err := NewPositionCache(t.Name(), repo, 1*time.Second)
 		r.NoError(err)
 

--- a/pkg/position_store/cache_test.go
+++ b/pkg/position_store/cache_test.go
@@ -24,7 +24,7 @@ func TestPositionCache_New(t *testing.T) {
 
 	t.Run("when repo has some data", func(tt *testing.T) {
 		repo := NewMemoRepo()
-		err := repo.Put(t.Name(), &PositionWithValueString{Value: "test", Stage: string(config.Stream)})
+		err := repo.Put(t.Name(), Position{ValueString: "test", Stage: config.Stream})
 		r.NoError(err)
 
 		cache, err := NewPositionCache(t.Name(), repo, StringEncoder, StringDecoder, DefaultFlushPeriod)

--- a/pkg/position_store/cache_test.go
+++ b/pkg/position_store/cache_test.go
@@ -47,7 +47,7 @@ func TestPositionCache_GetPut(t *testing.T) {
 		cache, err := NewPositionCache(t.Name(), repo, StringEncoder, StringDecoder, DefaultFlushPeriod)
 		r.NoError(err)
 
-		err = cache.Put(&Position{Value: ""})
+		err = cache.Put(Position{Value: ""})
 		r.NotNil(err)
 
 		_, exists, err := cache.Get()
@@ -59,7 +59,7 @@ func TestPositionCache_GetPut(t *testing.T) {
 		repo := NewMemoRepo()
 		cache, err := NewPositionCache(t.Name(), repo, StringEncoder, StringDecoder, DefaultFlushPeriod)
 		r.NoError(err)
-		err = cache.Put(&Position{Value: "test2", Stage: config.Stream})
+		err = cache.Put(Position{Value: "test2", Stage: config.Stream})
 		r.NoError(err)
 
 		p, exists, err := cache.Get()
@@ -67,7 +67,7 @@ func TestPositionCache_GetPut(t *testing.T) {
 		r.True(exists)
 		r.NoError(err)
 
-		err = cache.Put(&Position{Value: "test3", Stage: config.Stream})
+		err = cache.Put(Position{Value: "test3", Stage: config.Stream})
 		r.NoError(err)
 		p, exists, err = cache.Get()
 		r.NoError(err)
@@ -88,7 +88,7 @@ func TestDefaultPositionCache_Flush(t *testing.T) {
 
 		r.NoError(cache.Start())
 
-		err = cache.Put(&Position{Value: "test", Stage: config.Stream})
+		err = cache.Put(Position{Value: "test", Stage: config.Stream})
 		r.NoError(err)
 
 		p, exists, err := cache.Get()
@@ -103,7 +103,7 @@ func TestDefaultPositionCache_Flush(t *testing.T) {
 		r.Equal("test", m.Value)
 
 		// the second PUT will not flush data to repo until flush time comes
-		r.NoError(cache.Put(&Position{Value: "test2", Stage: config.Stream}))
+		r.NoError(cache.Put(Position{Value: "test2", Stage: config.Stream}))
 		p, exists, err = cache.Get()
 		r.NoError(err)
 		r.True(exists)
@@ -123,7 +123,7 @@ func TestDefaultPositionCache_Flush(t *testing.T) {
 
 		r.NoError(cache.Start())
 
-		err = cache.Put(&Position{Value: "test", Stage: config.Stream})
+		err = cache.Put(Position{Value: "test", Stage: config.Stream})
 		r.NoError(err)
 
 		p, exists, err := cache.Get()
@@ -138,7 +138,7 @@ func TestDefaultPositionCache_Flush(t *testing.T) {
 		r.Equal("test", m.Value)
 
 		// the second PUT will not flush data to repo until flush time comes
-		r.NoError(cache.Put(&Position{Value: "test2", Stage: config.Stream}))
+		r.NoError(cache.Put(Position{Value: "test2", Stage: config.Stream}))
 		p, exists, err = cache.Get()
 		r.NoError(err)
 		r.True(exists)

--- a/pkg/position_store/mem_repo.go
+++ b/pkg/position_store/mem_repo.go
@@ -1,10 +1,17 @@
 package position_store
 
 type memRepo struct {
-	positions map[string]Position
+	positions    map[string]Position
+	valueEncoder PositionValueEncoder
+	valueDecoder PositionValueDecoder
 }
 
 func (repo *memRepo) Get(pipelineName string) (Position, bool, error) {
+	p, ok := repo.positions[pipelineName]
+	return p, ok, nil
+}
+
+func (repo *memRepo) GetWithRawValue(pipelineName string) (Position, bool, error) {
 	p, ok := repo.positions[pipelineName]
 	return p, ok, nil
 }
@@ -21,6 +28,11 @@ func (repo *memRepo) Delete(pipelineName string) error {
 
 func (repo *memRepo) Close() error {
 	return nil
+}
+
+func (repo *memRepo) SetEncoderDecoder(encoder PositionValueEncoder, decoder PositionValueDecoder) {
+	repo.valueEncoder = encoder
+	repo.valueDecoder = decoder
 }
 
 func NewMemoRepo() PositionRepo {

--- a/pkg/position_store/mem_repo.go
+++ b/pkg/position_store/mem_repo.go
@@ -1,28 +1,21 @@
 package position_store
 
 type memRepo struct {
-	positions    map[string]Position
-	valueEncoder PositionValueEncoder
-	valueDecoder PositionValueDecoder
+	positionRepoModels map[string]*PositionRepoModel
 }
 
-func (repo *memRepo) Get(pipelineName string) (Position, bool, error) {
-	p, ok := repo.positions[pipelineName]
+func (repo *memRepo) Get(pipelineName string) (*PositionRepoModel, bool, error) {
+	p, ok := repo.positionRepoModels[pipelineName]
 	return p, ok, nil
 }
 
-func (repo *memRepo) GetWithRawValue(pipelineName string) (Position, bool, error) {
-	p, ok := repo.positions[pipelineName]
-	return p, ok, nil
-}
-
-func (repo *memRepo) Put(pipelineName string, position Position) error {
-	repo.positions[pipelineName] = position
+func (repo *memRepo) Put(pipelineName string, m *PositionRepoModel) error {
+	repo.positionRepoModels[pipelineName] = m
 	return nil
 }
 
 func (repo *memRepo) Delete(pipelineName string) error {
-	delete(repo.positions, pipelineName)
+	delete(repo.positionRepoModels, pipelineName)
 	return nil
 }
 
@@ -30,11 +23,6 @@ func (repo *memRepo) Close() error {
 	return nil
 }
 
-func (repo *memRepo) SetEncoderDecoder(encoder PositionValueEncoder, decoder PositionValueDecoder) {
-	repo.valueEncoder = encoder
-	repo.valueDecoder = decoder
-}
-
 func NewMemoRepo() PositionRepo {
-	return &memRepo{positions: make(map[string]Position)}
+	return &memRepo{positionRepoModels: make(map[string]*PositionRepoModel)}
 }

--- a/pkg/position_store/mem_repo.go
+++ b/pkg/position_store/mem_repo.go
@@ -20,6 +20,7 @@ func (repo *memRepo) Get(pipelineName string) (Position, bool, error) {
 }
 
 func (repo *memRepo) Put(pipelineName string, p Position) error {
+	p.Name = pipelineName
 	if err := p.ValidateWithValueString(); err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/position_store/mem_repo.go
+++ b/pkg/position_store/mem_repo.go
@@ -1,15 +1,15 @@
 package position_store
 
 type memRepo struct {
-	positionRepoModels map[string]*PositionRepoModel
+	positionRepoModels map[string]*PositionWithValueString
 }
 
-func (repo *memRepo) Get(pipelineName string) (*PositionRepoModel, bool, error) {
+func (repo *memRepo) Get(pipelineName string) (*PositionWithValueString, bool, error) {
 	p, ok := repo.positionRepoModels[pipelineName]
 	return p, ok, nil
 }
 
-func (repo *memRepo) Put(pipelineName string, m *PositionRepoModel) error {
+func (repo *memRepo) Put(pipelineName string, m *PositionWithValueString) error {
 	repo.positionRepoModels[pipelineName] = m
 	return nil
 }
@@ -24,5 +24,5 @@ func (repo *memRepo) Close() error {
 }
 
 func NewMemoRepo() PositionRepo {
-	return &memRepo{positionRepoModels: make(map[string]*PositionRepoModel)}
+	return &memRepo{positionRepoModels: make(map[string]*PositionWithValueString)}
 }

--- a/pkg/position_store/mem_repo.go
+++ b/pkg/position_store/mem_repo.go
@@ -2,30 +2,34 @@ package position_store
 
 import "github.com/juju/errors"
 
+type memPosition struct {
+	meta PositionMeta
+	v    string
+}
 type memRepo struct {
-	positionRepoModels map[string]Position
+	positionRepoModels map[string]memPosition
 }
 
-func (repo *memRepo) Get(pipelineName string) (Position, bool, error) {
+func (repo *memRepo) Get(pipelineName string) (PositionMeta, string, bool, error) {
 	p, ok := repo.positionRepoModels[pipelineName]
 	if ok {
-		if err := p.ValidateWithValueString(); err != nil {
-			return Position{}, true, errors.Trace(err)
+		if err := p.meta.Validate(); err != nil {
+			return PositionMeta{}, "", true, errors.Trace(err)
 		} else {
-			return p, true, nil
+			return p.meta, p.v, true, nil
 		}
 	} else {
-		return Position{}, false, nil
+		return PositionMeta{}, "", false, nil
 	}
 }
 
-func (repo *memRepo) Put(pipelineName string, p Position) error {
-	p.Name = pipelineName
-	if err := p.ValidateWithValueString(); err != nil {
+func (repo *memRepo) Put(pipelineName string, meta PositionMeta, v string) error {
+	meta.Name = pipelineName
+	if err := meta.Validate(); err != nil {
 		return errors.Trace(err)
 	}
 
-	repo.positionRepoModels[pipelineName] = p
+	repo.positionRepoModels[pipelineName] = memPosition{meta: meta, v: v}
 	return nil
 }
 
@@ -39,5 +43,5 @@ func (repo *memRepo) Close() error {
 }
 
 func NewMemoRepo() PositionRepo {
-	return &memRepo{positionRepoModels: make(map[string]Position)}
+	return &memRepo{positionRepoModels: make(map[string]memPosition)}
 }

--- a/pkg/position_store/mongo_repo.go
+++ b/pkg/position_store/mongo_repo.go
@@ -38,9 +38,9 @@ type mongoPositionRepo struct {
 	session *mgo.Session
 }
 
-func (repo *mongoPositionRepo) Get(pipelineName string) (*PositionRepoModel, bool, error) {
+func (repo *mongoPositionRepo) Get(pipelineName string) (*PositionWithValueString, bool, error) {
 	collection := repo.session.DB(mongoPositionDB).C(mongoPositionCollection)
-	model := PositionRepoModel{}
+	model := PositionWithValueString{}
 	err := collection.Find(bson.M{"name": pipelineName}).One(&model)
 	if err != nil {
 		if err == mgo.ErrNotFound {
@@ -61,14 +61,14 @@ func (repo *mongoPositionRepo) Get(pipelineName string) (*PositionRepoModel, boo
 			return nil, true, errors.Trace(err)
 		}
 
-		return &PositionRepoModel{Name: pipelineName, Stage: oldPosition.Stage, Value: s}, true, nil
+		return &PositionWithValueString{Name: pipelineName, Stage: oldPosition.Stage, Value: s}, true, nil
 
 	}
 
 	return &model, true, nil
 }
 
-func (repo *mongoPositionRepo) Put(pipelineName string, model *PositionRepoModel) error {
+func (repo *mongoPositionRepo) Put(pipelineName string, model *PositionWithValueString) error {
 
 	collection := repo.session.DB(mongoPositionDB).C(mongoPositionCollection)
 	_, err := collection.Upsert(

--- a/pkg/position_store/mongo_repo.go
+++ b/pkg/position_store/mongo_repo.go
@@ -27,6 +27,8 @@ type MongoPosition struct {
 	StartPosition   config.MongoPosition `json:"start_position" bson:"start_position"`
 	CurrentPosition config.MongoPosition `json:"current_position" bson:"current_position"`
 }
+
+// PositionEntity is the old format, will be deprecated
 type PositionEntity struct {
 	Name          string `json:"name" bson:"name"`
 	Stage         string `json:"stage" bson:"stage"`
@@ -34,57 +36,86 @@ type PositionEntity struct {
 	LastUpdate    string `json:"last_update" bson:"last_update"`
 }
 
+// MongoPositionRet is the new format
+type MongoPositionRet struct {
+	Version    string `json:"version" bson:"version"`
+	Name       string `json:"name" bson:"name"`
+	Stage      string `json:"stage" bson:"stage"`
+	Value      string `json:"value" bson:"value"`
+	LastUpdate string `json:"last_update" bson:"last_update"`
+}
+
 type mongoPositionRepo struct {
 	session *mgo.Session
 }
 
-func (repo *mongoPositionRepo) Get(pipelineName string) (Position, bool, error) {
+type PositionWrapper struct {
+	PositionMeta
+	MongoValue string `bson:"value" json:"value"`
+}
+
+func (repo *mongoPositionRepo) Get(pipelineName string) (PositionMeta, string, bool, error) {
 	collection := repo.session.DB(mongoPositionDB).C(mongoPositionCollection)
-	position := Position{}
-	err := collection.Find(bson.M{"name": pipelineName}).One(&position)
+	mongoRet := MongoPositionRet{}
+	err := collection.Find(bson.M{"name": pipelineName}).One(&mongoRet)
 	if err != nil {
 		if err == mgo.ErrNotFound {
-			return Position{}, false, nil
+			return PositionMeta{}, "", false, nil
 		}
-		return Position{}, false, errors.Trace(err)
+		return PositionMeta{}, "", false, errors.Trace(err)
 	}
 
-	// backward compatible with old position schema
-	if position.Version == "" {
+	// backward compatible with old mongoRet schema
+	if mongoRet.Version == "" {
 		oldPosition := PositionEntity{}
 		if err := collection.Find(bson.M{"name": pipelineName}).One(&oldPosition); err != nil {
-			return Position{}, true, errors.Trace(err)
+			return PositionMeta{}, "", true, errors.Trace(err)
 		}
 
 		s, err := myJson.MarshalToString(&oldPosition.MongoPosition)
 		if err != nil {
-			return Position{}, true, errors.Trace(err)
+			return PositionMeta{}, "", true, errors.Trace(err)
 		}
 
-		return Position{Name: pipelineName, Stage: config.InputMode(oldPosition.Stage), ValueString: s}, true, nil
+		return PositionMeta{Name: pipelineName, Stage: config.InputMode(oldPosition.Stage)}, s, true, nil
 
 	}
 
-	if err := position.ValidateWithValueString(); err != nil {
-		return Position{}, true, errors.Trace(err)
+	t, err := time.Parse(time.RFC3339Nano, mongoRet.LastUpdate)
+	if err != nil {
+		return PositionMeta{}, "", true, errors.Trace(err)
 	}
 
-	return position, true, nil
+	meta := PositionMeta{Name: mongoRet.Name, Stage: config.InputMode(mongoRet.Stage), UpdateTime: t}
+	if err := meta.Validate(); err != nil {
+		return PositionMeta{}, "", true, errors.Trace(err)
+	}
+
+	if mongoRet.Value == "" {
+		return PositionMeta{}, "", true, errors.Errorf("empty value")
+	}
+
+	return meta, mongoRet.Value, true, nil
 }
 
-func (repo *mongoPositionRepo) Put(pipelineName string, position Position) error {
-	position.Name = pipelineName
-	if err := position.ValidateWithValueString(); err != nil {
+func (repo *mongoPositionRepo) Put(pipelineName string, meta PositionMeta, v string) error {
+	meta.Name = pipelineName
+	meta.Version = Version
+	if err := meta.Validate(); err != nil {
 		return errors.Trace(err)
+	}
+
+	if v == "" {
+		return errors.Errorf("empty value")
 	}
 
 	collection := repo.session.DB(mongoPositionDB).C(mongoPositionCollection)
 	_, err := collection.Upsert(
 		bson.M{"name": pipelineName}, bson.M{
 			"$set": bson.M{
-				"version":     Version,
-				"stage":       string(position.Stage),
-				"value":       position.ValueString,
+				"version":     meta.Version,
+				"stage":       string(meta.Stage),
+				"value":       v,
 				"last_update": time.Now().Format(time.RFC3339Nano),
 			},
 		})

--- a/pkg/position_store/mongo_repo_test.go
+++ b/pkg/position_store/mongo_repo_test.go
@@ -30,7 +30,7 @@ func TestMongoPositionRepo_Get(t *testing.T) {
 	})
 
 	t.Run("insert one record", func(tt *testing.T) {
-		err := repo.Put(tt.Name(), &PositionRepoModel{Stage: string(config.Stream), Value: "test"})
+		err := repo.Put(tt.Name(), &PositionWithValueString{Stage: string(config.Stream), Value: "test"})
 		r.NoError(err)
 
 		position, exists, err := repo.Get(tt.Name())

--- a/pkg/position_store/mysql_repo.go
+++ b/pkg/position_store/mysql_repo.go
@@ -38,14 +38,14 @@ type mysqlPositionRepo struct {
 	annotation string
 }
 
-func (repo *mysqlPositionRepo) Get(pipelineName string) (*PositionRepoModel, bool, error) {
+func (repo *mysqlPositionRepo) Get(pipelineName string) (*PositionWithValueString, bool, error) {
 	value, stage, lastUpdate, exists, err := repo.getRaw(pipelineName)
 	if err != nil {
 		return nil, exists, errors.Trace(err)
 	}
 
 	if exists {
-		m := PositionRepoModel{Name: pipelineName, Stage: stage, Value: value, UpdateTime: lastUpdate}
+		m := PositionWithValueString{Name: pipelineName, Stage: stage, Value: value, UpdateTime: lastUpdate}
 
 		if err := m.Validate(); err != nil {
 			return nil, true, errors.Trace(err)
@@ -70,7 +70,7 @@ func (repo *mysqlPositionRepo) getRaw(pipelineName string) (value string, stage 
 	return value, stage, lastUpdate, true, nil
 }
 
-func (repo *mysqlPositionRepo) Put(pipelineName string, m *PositionRepoModel) error {
+func (repo *mysqlPositionRepo) Put(pipelineName string, m *PositionWithValueString) error {
 	if err := m.Validate(); err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/position_store/mysql_repo_test.go
+++ b/pkg/position_store/mysql_repo_test.go
@@ -25,30 +25,30 @@ func TestMysqlPositionRepo_GetPut(t *testing.T) {
 	r.False(exist)
 
 	// put first value
-	position := PositionWithValueString{
-		Name:  t.Name(),
-		Stage: string(config.Stream),
-		Value: "test",
+	position := Position{
+		Name:        t.Name(),
+		Stage:       config.Stream,
+		ValueString: "test",
 	}
-	r.NoError(repo.Put(t.Name(), &position))
+	r.NoError(repo.Put(t.Name(), position))
 
 	p, exist, err := repo.Get(t.Name())
 	r.NoError(err)
 	r.True(exist)
-	r.Equal("test", p.Value)
-	r.Equal(string(config.Stream), p.Stage)
+	r.Equal("test", p.ValueString)
+	r.Equal(config.Stream, p.Stage)
 
 	// put another value
-	position.Value = "test2"
-	r.NoError(repo.Put(t.Name(), &position))
+	position.ValueString = "test2"
+	r.NoError(repo.Put(t.Name(), position))
 
 	p2, exist, err := repo.Get(t.Name())
 	r.NoError(err)
 	r.True(exist)
-	r.Equal(p2.Value, "test2")
+	r.Equal(p2.ValueString, "test2")
 
 	// put an invalid value
-	position.Value = ""
-	err = repo.Put(t.Name(), &position)
+	position.ValueString = ""
+	err = repo.Put(t.Name(), position)
 	r.NotNil(err)
 }

--- a/pkg/position_store/mysql_repo_test.go
+++ b/pkg/position_store/mysql_repo_test.go
@@ -19,36 +19,33 @@ func TestMysqlPositionRepo_GetPut(t *testing.T) {
 	// delete it first
 	r.NoError(repo.Delete(t.Name()))
 
-	_, exist, err := repo.Get(t.Name())
+	_, _, exist, err := repo.Get(t.Name())
 	r.NoError(err)
 
 	r.False(exist)
 
 	// put first value
-	position := Position{
-		Name:        t.Name(),
-		Stage:       config.Stream,
-		ValueString: "test",
+	meta := PositionMeta{
+		Name:  t.Name(),
+		Stage: config.Stream,
 	}
-	r.NoError(repo.Put(t.Name(), position))
+	r.NoError(repo.Put(t.Name(), meta, "test"))
 
-	p, exist, err := repo.Get(t.Name())
+	meta, v, exist, err := repo.Get(t.Name())
 	r.NoError(err)
 	r.True(exist)
-	r.Equal("test", p.ValueString)
-	r.Equal(config.Stream, p.Stage)
+	r.Equal("test", v)
+	r.Equal(config.Stream, meta.Stage)
 
 	// put another value
-	position.ValueString = "test2"
-	r.NoError(repo.Put(t.Name(), position))
+	r.NoError(repo.Put(t.Name(), meta, "test2"))
 
-	p2, exist, err := repo.Get(t.Name())
+	meta, v, exist, err = repo.Get(t.Name())
 	r.NoError(err)
 	r.True(exist)
-	r.Equal(p2.ValueString, "test2")
+	r.Equal("test2", v)
 
 	// put an invalid value
-	position.ValueString = ""
-	err = repo.Put(t.Name(), position)
+	err = repo.Put(t.Name(), meta, "")
 	r.NotNil(err)
 }

--- a/pkg/position_store/mysql_repo_test.go
+++ b/pkg/position_store/mysql_repo_test.go
@@ -25,7 +25,7 @@ func TestMysqlPositionRepo_GetPut(t *testing.T) {
 	r.False(exist)
 
 	// put first value
-	position := PositionRepoModel{
+	position := PositionWithValueString{
 		Name:  t.Name(),
 		Stage: string(config.Stream),
 		Value: "test",

--- a/pkg/position_store/mysql_repo_test.go
+++ b/pkg/position_store/mysql_repo_test.go
@@ -16,6 +16,8 @@ func TestMysqlPositionRepo_GetPut(t *testing.T) {
 	repo, err := NewMySQLRepo(dbCfg, "")
 	r.NoError(err)
 
+	repo.SetEncoderDecoder(StringEncoder, StringDecoder)
+
 	// delete it first
 	r.NoError(repo.Delete(t.Name()))
 
@@ -48,7 +50,7 @@ func TestMysqlPositionRepo_GetPut(t *testing.T) {
 	r.Equal(p2.Value, "test2")
 
 	// put an invalid value
-	position.Value = ""
+	position.Value = nil
 	err = repo.Put(t.Name(), position)
 	r.NotNil(err)
 }

--- a/pkg/position_store/mysql_repo_test.go
+++ b/pkg/position_store/mysql_repo_test.go
@@ -16,8 +16,6 @@ func TestMysqlPositionRepo_GetPut(t *testing.T) {
 	repo, err := NewMySQLRepo(dbCfg, "")
 	r.NoError(err)
 
-	repo.SetEncoderDecoder(StringEncoder, StringDecoder)
-
 	// delete it first
 	r.NoError(repo.Delete(t.Name()))
 
@@ -27,22 +25,22 @@ func TestMysqlPositionRepo_GetPut(t *testing.T) {
 	r.False(exist)
 
 	// put first value
-	position := Position{
+	position := PositionRepoModel{
 		Name:  t.Name(),
-		Stage: config.Stream,
+		Stage: string(config.Stream),
 		Value: "test",
 	}
-	r.NoError(repo.Put(t.Name(), position))
+	r.NoError(repo.Put(t.Name(), &position))
 
 	p, exist, err := repo.Get(t.Name())
 	r.NoError(err)
 	r.True(exist)
 	r.Equal("test", p.Value)
-	r.Equal(config.Stream, p.Stage)
+	r.Equal(string(config.Stream), p.Stage)
 
 	// put another value
 	position.Value = "test2"
-	r.NoError(repo.Put(t.Name(), position))
+	r.NoError(repo.Put(t.Name(), &position))
 
 	p2, exist, err := repo.Get(t.Name())
 	r.NoError(err)
@@ -50,7 +48,7 @@ func TestMysqlPositionRepo_GetPut(t *testing.T) {
 	r.Equal(p2.Value, "test2")
 
 	// put an invalid value
-	position.Value = nil
-	err = repo.Put(t.Name(), position)
+	position.Value = ""
+	err = repo.Put(t.Name(), &position)
 	r.NotNil(err)
 }

--- a/pkg/position_store/position.go
+++ b/pkg/position_store/position.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+
 	"github.com/moiot/gravity/pkg/config"
 )
 
@@ -33,13 +34,41 @@ type Position struct {
 	UpdateTime time.Time
 }
 
-func (p Position) Validate() error {
+func (p *Position) Validate() error {
 	if p.Stage != config.Stream && p.Stage != config.Batch {
 		return errors.Errorf("invalid position stage: %v", p.Stage)
 	}
 
 	if p.Value == nil {
 		return errors.Errorf("empty position value: %v", p.Value)
+	}
+
+	if p.Name == "" {
+		return errors.Errorf("empty name")
+	}
+
+	return nil
+}
+
+type PositionRepoModel struct {
+	Version    string
+	Name       string
+	Stage      string
+	Value      string
+	UpdateTime time.Time
+}
+
+func (m *PositionRepoModel) Validate() error {
+	if m.Stage != string(config.Stream) && m.Stage != string(config.Batch) {
+		return errors.Errorf("invalid stage: %v", m.Stage)
+	}
+
+	if m.Value == "" {
+		return errors.Errorf("empty position value")
+	}
+
+	if m.Name == "" {
+		return errors.Errorf("empty name")
 	}
 
 	return nil

--- a/pkg/position_store/position.go
+++ b/pkg/position_store/position.go
@@ -28,19 +28,16 @@ type Position struct {
 	// Version is the schema version of position
 	Version string
 	// Name is the unique name of a pipeline
-	Name       string
-	Stage      config.InputMode
-	Value      interface{}
-	UpdateTime time.Time
+	Name        string
+	Stage       config.InputMode
+	Value       interface{} `bson:"-" json:"-"`
+	ValueString string      `bson:"value" json:"value"`
+	UpdateTime  time.Time
 }
 
-func (p *Position) Validate() error {
+func (p Position) ValidateWithoutValue() error {
 	if p.Stage != config.Stream && p.Stage != config.Batch {
 		return errors.Errorf("invalid position stage: %v", p.Stage)
-	}
-
-	if p.Value == nil {
-		return errors.Errorf("empty position value: %v", p.Value)
 	}
 
 	if p.Name == "" {
@@ -50,25 +47,25 @@ func (p *Position) Validate() error {
 	return nil
 }
 
-type PositionWithValueString struct {
-	Version    string
-	Name       string
-	Stage      string
-	Value      string
-	UpdateTime time.Time
+func (p Position) ValidateWithValue() error {
+	if err := p.ValidateWithoutValue(); err != nil {
+		return errors.Trace(err)
+	}
+
+	if p.Value == nil {
+		return errors.Errorf("empty position value: %v", p.Value)
+	}
+
+	return nil
 }
 
-func (m *PositionWithValueString) Validate() error {
-	if m.Stage != string(config.Stream) && m.Stage != string(config.Batch) {
-		return errors.Errorf("invalid stage: %v", m.Stage)
+func (p Position) ValidateWithValueString() error {
+	if err := p.ValidateWithoutValue(); err != nil {
+		return errors.Trace(err)
 	}
 
-	if m.Value == "" {
-		return errors.Errorf("empty position value")
-	}
-
-	if m.Name == "" {
-		return errors.Errorf("empty name")
+	if p.ValueString == "" {
+		return errors.Errorf("empty value string")
 	}
 
 	return nil

--- a/pkg/position_store/position.go
+++ b/pkg/position_store/position.go
@@ -1,0 +1,46 @@
+/*
+ *
+ * // Copyright 2019 , Beijing Mobike Technology Co., Ltd.
+ * //
+ * // Licensed under the Apache License, Version 2.0 (the "License");
+ * // you may not use this file except in compliance with the License.
+ * // You may obtain a copy of the License at
+ * //
+ * //     http://www.apache.org/licenses/LICENSE-2.0
+ * //
+ * // Unless required by applicable law or agreed to in writing, software
+ * // distributed under the License is distributed on an "AS IS" BASIS,
+ * // See the License for the specific language governing permissions and
+ * // limitations under the License.
+ */
+
+package position_store
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/moiot/gravity/pkg/config"
+)
+
+type Position struct {
+	// Version is the schema version of position
+	Version string
+	// Name is the unique name of a pipeline
+	Name       string
+	Stage      config.InputMode
+	Value      interface{}
+	UpdateTime time.Time
+}
+
+func (p Position) Validate() error {
+	if p.Stage != config.Stream && p.Stage != config.Batch {
+		return errors.Errorf("invalid position stage: %v", p.Stage)
+	}
+
+	if p.Value == nil {
+		return errors.Errorf("empty position value: %v", p.Value)
+	}
+
+	return nil
+}

--- a/pkg/position_store/position.go
+++ b/pkg/position_store/position.go
@@ -50,7 +50,7 @@ func (p *Position) Validate() error {
 	return nil
 }
 
-type PositionRepoModel struct {
+type PositionWithValueString struct {
 	Version    string
 	Name       string
 	Stage      string
@@ -58,7 +58,7 @@ type PositionRepoModel struct {
 	UpdateTime time.Time
 }
 
-func (m *PositionRepoModel) Validate() error {
+func (m *PositionWithValueString) Validate() error {
 	if m.Stage != string(config.Stream) && m.Stage != string(config.Batch) {
 		return errors.Errorf("invalid stage: %v", m.Stage)
 	}

--- a/pkg/position_store/position.go
+++ b/pkg/position_store/position.go
@@ -24,48 +24,39 @@ import (
 	"github.com/moiot/gravity/pkg/config"
 )
 
-type Position struct {
+type PositionMeta struct {
 	// Version is the schema version of position
-	Version string
+	Version string `bson:"version" json:"version"`
 	// Name is the unique name of a pipeline
-	Name        string
-	Stage       config.InputMode
-	Value       interface{} `bson:"-" json:"-"`
-	ValueString string      `bson:"value" json:"value"`
-	UpdateTime  time.Time
+	Name       string
+	Stage      config.InputMode
+	UpdateTime time.Time
 }
 
-func (p Position) ValidateWithoutValue() error {
-	if p.Stage != config.Stream && p.Stage != config.Batch {
-		return errors.Errorf("invalid position stage: %v", p.Stage)
+func (meta PositionMeta) Validate() error {
+	if meta.Stage != config.Stream && meta.Stage != config.Batch {
+		return errors.Errorf("invalid position stage: %v", meta.Stage)
 	}
 
-	if p.Name == "" {
+	if meta.Name == "" {
 		return errors.Errorf("empty name")
 	}
 
 	return nil
 }
 
-func (p Position) ValidateWithValue() error {
-	if err := p.ValidateWithoutValue(); err != nil {
+type Position struct {
+	PositionMeta
+	Value interface{} `bson:"-" json:"-"`
+}
+
+func (p Position) Validate() error {
+	if err := p.PositionMeta.Validate(); err != nil {
 		return errors.Trace(err)
 	}
 
 	if p.Value == nil {
 		return errors.Errorf("empty position value: %v", p.Value)
-	}
-
-	return nil
-}
-
-func (p Position) ValidateWithValueString() error {
-	if err := p.ValidateWithoutValue(); err != nil {
-		return errors.Trace(err)
-	}
-
-	if p.ValueString == "" {
-		return errors.Errorf("empty value string")
 	}
 
 	return nil

--- a/pkg/position_store/repo.go
+++ b/pkg/position_store/repo.go
@@ -1,7 +1,12 @@
 package position_store
 
+type PositionValueEncoder func(v interface{}) (string, error)
+type PositionValueDecoder func(s string) (interface{}, error)
+
 type PositionRepo interface {
+	SetEncoderDecoder(encoder PositionValueEncoder, decoder PositionValueDecoder)
 	Get(pipelineName string) (Position, bool, error)
+	GetWithRawValue(pipelineName string) (Position, bool, error)
 	Put(pipelineName string, position Position) error
 	Delete(pipelineName string) error
 	Close() error

--- a/pkg/position_store/repo.go
+++ b/pkg/position_store/repo.go
@@ -4,8 +4,8 @@ type PositionValueEncoder func(v interface{}) (string, error)
 type PositionValueDecoder func(s string) (interface{}, error)
 
 type PositionRepo interface {
-	Get(pipelineName string) (Position, bool, error)
-	Put(pipelineName string, position Position) error
+	Get(pipelineName string) (PositionMeta, string, bool, error)
+	Put(pipelineName string, positionMeta PositionMeta, v string) error
 	Delete(pipelineName string) error
 	Close() error
 }

--- a/pkg/position_store/repo.go
+++ b/pkg/position_store/repo.go
@@ -4,8 +4,8 @@ type PositionValueEncoder func(v interface{}) (string, error)
 type PositionValueDecoder func(s string) (interface{}, error)
 
 type PositionRepo interface {
-	Get(pipelineName string) (*PositionWithValueString, bool, error)
-	Put(pipelineName string, position *PositionWithValueString) error
+	Get(pipelineName string) (Position, bool, error)
+	Put(pipelineName string, position Position) error
 	Delete(pipelineName string) error
 	Close() error
 }

--- a/pkg/position_store/repo.go
+++ b/pkg/position_store/repo.go
@@ -4,8 +4,8 @@ type PositionValueEncoder func(v interface{}) (string, error)
 type PositionValueDecoder func(s string) (interface{}, error)
 
 type PositionRepo interface {
-	Get(pipelineName string) (*PositionRepoModel, bool, error)
-	Put(pipelineName string, position *PositionRepoModel) error
+	Get(pipelineName string) (*PositionWithValueString, bool, error)
+	Put(pipelineName string, position *PositionWithValueString) error
 	Delete(pipelineName string) error
 	Close() error
 }

--- a/pkg/position_store/repo.go
+++ b/pkg/position_store/repo.go
@@ -4,10 +4,8 @@ type PositionValueEncoder func(v interface{}) (string, error)
 type PositionValueDecoder func(s string) (interface{}, error)
 
 type PositionRepo interface {
-	SetEncoderDecoder(encoder PositionValueEncoder, decoder PositionValueDecoder)
-	Get(pipelineName string) (Position, bool, error)
-	GetWithRawValue(pipelineName string) (Position, bool, error)
-	Put(pipelineName string, position Position) error
+	Get(pipelineName string) (*PositionRepoModel, bool, error)
+	Put(pipelineName string, position *PositionRepoModel) error
 	Delete(pipelineName string) error
 	Close() error
 }

--- a/pkg/position_store/testing.go
+++ b/pkg/position_store/testing.go
@@ -1,0 +1,27 @@
+/*
+ *
+ * // Copyright 2019 , Beijing Mobike Technology Co., Ltd.
+ * //
+ * // Licensed under the Apache License, Version 2.0 (the "License");
+ * // you may not use this file except in compliance with the License.
+ * // You may obtain a copy of the License at
+ * //
+ * //     http://www.apache.org/licenses/LICENSE-2.0
+ * //
+ * // Unless required by applicable law or agreed to in writing, software
+ * // distributed under the License is distributed on an "AS IS" BASIS,
+ * // See the License for the specific language governing permissions and
+ * // limitations under the License.
+ */
+
+package position_store
+
+import "fmt"
+
+func StringEncoder(v interface{}) (string, error) {
+	return fmt.Sprintf("%s", v), nil
+}
+
+func StringDecoder(s string) (interface{}, error) {
+	return s, nil
+}

--- a/pkg/utils/db.go
+++ b/pkg/utils/db.go
@@ -592,6 +592,10 @@ type MySQLBinlogPosition struct {
 	BinlogGTID     string `toml:"binlog-gtid" json:"binlog-gtid" mapstructure:"binlog-gtid"`
 }
 
+func (p MySQLBinlogPosition) Empty() bool {
+	return p.BinlogGTID == ""
+}
+
 func TableIdentity(schemaName string, tableName string) string {
 	return fmt.Sprintf("`%s`.`%s`", schemaName, tableName)
 }

--- a/pkg/utils/db.go
+++ b/pkg/utils/db.go
@@ -592,10 +592,6 @@ type MySQLBinlogPosition struct {
 	BinlogGTID     string `toml:"binlog-gtid" json:"binlog-gtid" mapstructure:"binlog-gtid"`
 }
 
-func (p MySQLBinlogPosition) Empty() bool {
-	return p.BinlogGTID == ""
-}
-
 func TableIdentity(schemaName string, tableName string) string {
 	return fmt.Sprintf("`%s`.`%s`", schemaName, tableName)
 }


### PR DESCRIPTION
1. Only do the serialization when use repo to persist position.

2. Clarify the interface of Cache and Repo.
   - Deprecate the use of pointer in the interface to avoid race conditions.

3. Do not send the table scan job when the table is already scanned.
