### PR TITLE
fix gtid reset

### DIFF
--- a/pkg/inputs/mysqlbatch/mysql_table_scanner_test.go
+++ b/pkg/inputs/mysqlbatch/mysql_table_scanner_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math/rand"
+	"reflect"
 	"testing"
 	"time"
 
@@ -43,7 +44,11 @@ func TestFindMaxMinValueCompositePks(t *testing.T) {
 	max, min := FindMaxMinValueFromDB(db, testDBName, mysql_test.TestScanColumnTableCompositePrimaryOutOfOrder, []string{"email", "name"})
 
 	maxEmail, ok := max[0].(sql.NullString)
+
+	fmt.Printf("maxEmail type: %v\n", reflect.TypeOf(max[0]))
+
 	r.True(ok)
+
 	r.Equal("email_99", maxEmail.String)
 
 	maxName, ok := max[1].(sql.NullString)
@@ -74,13 +79,16 @@ func TestFindMaxMinValueInt(t *testing.T) {
 		r.NoError(err)
 	}
 
+	r.NoError(mysql_test.InsertIntoTestTable(db, testDBName, mysql_test.TestTableName, map[string]interface{}{"id": 5000}))
+	r.NoError(mysql_test.InsertIntoTestTable(db, testDBName, mysql_test.TestTableName, map[string]interface{}{"id": 1410812506}))
+
 	max, min := FindMaxMinValueFromDB(db, testDBName, mysql_test.TestTableName, []string{"id"})
 
-	maxVal, ok := max[0].(uint32)
+	maxVal, ok := max[0].(int64)
+	r.True(ok)
+	r.EqualValues(1410812506, maxVal)
 
-	r.EqualValues(99, maxVal)
-
-	minVal, ok := min[0].(uint32)
+	minVal, ok := min[0].(int64)
 	r.True(ok)
 
 	r.EqualValues(1, minVal)

--- a/pkg/inputs/mysqlbatch/position_value.go
+++ b/pkg/inputs/mysqlbatch/position_value.go
@@ -142,7 +142,7 @@ func (p *TablePosition) UnmarshalJSON(value []byte) error {
 	case PlainString:
 		p.Value = pMapString["value"]
 	case PlainInt:
-		v, err := strconv.Atoi(pMapString["value"])
+		v, err := strconv.ParseInt(pMapString["value"], 10, 64)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -159,7 +159,7 @@ func (p *TablePosition) UnmarshalJSON(value []byte) error {
 		// s := []byte(pMapString["value"])
 		p.Value = pMapString["value"]
 	case SQLNullInt64:
-		v, err := strconv.Atoi(pMapString["value"])
+		v, err := strconv.ParseInt(pMapString["value"], 10, 64)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/pkg/inputs/mysqlstream/position_value_test.go
+++ b/pkg/inputs/mysqlstream/position_value_test.go
@@ -69,10 +69,6 @@ func TestSetupInitialPosition(t *testing.T) {
 			// it should use the start spec as the start position and current position.
 			//
 			pipelineName := utils.TestCaseMd5Name(ttt)
-			startGTID := "abc:123"
-			currentGTID := "abc:789"
-			err := initRepo(repo, pipelineName, startGTID, currentGTID)
-			r.NoError(err)
 
 			cache, err := position_store.NewPositionCache(
 				pipelineName,
@@ -83,9 +79,9 @@ func TestSetupInitialPosition(t *testing.T) {
 			r.NoError(err)
 
 			db := mysql_test.MustSetupSourceDB(pipelineName)
-			newGTID := "abc:999"
+			gtid := "abc:999"
 			specStart := utils.MySQLBinlogPosition{
-				BinlogGTID: newGTID,
+				BinlogGTID: gtid,
 			}
 
 			err = SetupInitialPosition(db, cache, &specStart)
@@ -97,8 +93,8 @@ func TestSetupInitialPosition(t *testing.T) {
 			newPositionValue, ok := p.Value.(helper.BinlogPositionsValue)
 			r.True(ok)
 
-			r.Equal(newGTID, newPositionValue.StartPosition.BinlogGTID)
-			r.Equal(newGTID, newPositionValue.CurrentPosition.BinlogGTID)
+			r.Equal(gtid, newPositionValue.StartPosition.BinlogGTID)
+			r.Equal(gtid, newPositionValue.CurrentPosition.BinlogGTID)
 		})
 	})
 

--- a/pkg/mysql_test/test.go
+++ b/pkg/mysql_test/test.go
@@ -39,7 +39,7 @@ const (
 
 var setupSqls = []string{
 	fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
-  id int(11) unsigned NOT NULL,
+  id bigint(20) NOT NULL,
   name varchar(256) DEFAULT NULL,
   email varchar(30) COLLATE utf8mb4_bin NOT NULL DEFAULT 'default_email',
   ts TIMESTAMP,

--- a/pkg/schema_store/utils_test.go
+++ b/pkg/schema_store/utils_test.go
@@ -31,7 +31,7 @@ func TestSchemaStoreUtils(t *testing.T) {
 		assert.Equal("id", table.Columns[0].Name)
 		assert.Equal(0, table.Columns[0].Idx)
 		assert.False(table.Columns[0].IsNullable)
-		assert.True(table.Columns[0].IsUnsigned)
+		assert.False(table.Columns[0].IsUnsigned)
 		assert.True(table.Columns[0].IsPrimaryKey)
 		assert.Equal("id", table.PrimaryKeyColumns[0].Name)
 		assert.Equal("id", table.UniqueKeyColumnMap["PRIMARY"][0])

--- a/pkg/utils/db.go
+++ b/pkg/utils/db.go
@@ -139,10 +139,6 @@ var nullString = reflect.TypeOf(sql.NullString{})
 func GetScanType(columnType *sql.ColumnType) reflect.Type {
 	if IsColumnString(columnType) {
 		return reflect.TypeOf(sql.NullString{})
-	} else if columnType.DatabaseTypeName() == "DECIMAL" {
-		return nullString
-	} else if columnType.DatabaseTypeName() == "BIGINT" { // go-mysql can't handle unsigned nullable bigint
-		return nullString
 	} else {
 		return columnType.ScanType()
 	}
@@ -204,7 +200,7 @@ func ScanGeneralRowsWithDataPtrs(rows *sql.Rows, columnTypes []*sql.ColumnType, 
 func ScanGeneralRows(rows *sql.Rows, columnTypes []*sql.ColumnType) ([]interface{}, error) {
 	vPtrs := make([]interface{}, len(columnTypes))
 
-	for i, _ := range columnTypes {
+	for i := range columnTypes {
 		scanType := GetScanType(columnTypes[i])
 		vptr := reflect.New(scanType)
 		vPtrs[i] = vptr.Interface()
@@ -214,7 +210,7 @@ func ScanGeneralRows(rows *sql.Rows, columnTypes []*sql.ColumnType) ([]interface
 	}
 
 	// copy sql.RawBytes from db to here
-	for i, _ := range columnTypes {
+	for i := range columnTypes {
 		p, err := GetScanPtrSafe(i, columnTypes, vPtrs)
 		if err != nil {
 			return nil, errors.Trace(err)


### PR DESCRIPTION
- fix bug on gtid start position

   when the spec has start position, we actually didn't respect the spec's start position; and the test was inconsistent with the intension.

- fix bug on int primary key scan.
   
   When primary key is int, the scanned value was converted to string, and broke the comparison using `select a > b`