### PR TITLE
init grpc server lazily

### DIFF
--- a/pkg/filters/grpc_sidecar_filter.go
+++ b/pkg/filters/grpc_sidecar_filter.go
@@ -131,6 +131,8 @@ func (f *grpcFilterType) Filter(msg *core.Msg) (bool, error) {
 
 func (f *grpcFilterType) Close() error {
 	f.client.Kill()
+	f.client = nil
+	f.delegate = nil
 	return nil
 }
 


### PR DESCRIPTION
Filter's `Configure` has side effect. We cannot delete pipeline with grpc plugin.

This PR delete the side effect in `Configure` and init grpc server lazily.