### PR TITLE
[output-elasticsearch] provide http timeout setting

### DIFF
--- a/docs/2.0/04-outputs-en.md
+++ b/docs/2.0/04-outputs-en.md
@@ -155,7 +155,7 @@ In the above configuration, if `use-bidirection` is set to "true" as follows, DR
 use-bidirection = true
 ```
 
-### Elasticsearch
+## `elasticsearch` configuration
 
 Important notices:
 
@@ -179,6 +179,8 @@ ignore-bad-request = true
 [output.config.server]
 urls = ["http://127.0.0.1:9200"]
 sniff = false
+# http timeout, default is 1000ms
+timeout = 500
 
 #
 # The basic auth configuration

--- a/docs/2.0/04-outputs.md
+++ b/docs/2.0/04-outputs.md
@@ -184,6 +184,8 @@ ignore-bad-request = true
 urls = ["http://127.0.0.1:9200"]
 # 是否进行节点嗅探，默认为 false
 sniff = false
+# 超时时间，默认为 1000ms
+timeout = 500
 
 #
 # 目标端鉴权配置


### PR DESCRIPTION
We found that the long tail latency of elasticsearch output(e.g. p999: 3500ms) sometimes block the workers, and causing the throughput to decrease. 

So we need to provide a timeout setting for elasticsearch client, then the scheduler will retry when a timeout occurs.

@Ryan-Git  please take a look.