### PR TITLE
fix TiDB DEFAULT_GENERATED

### DIFF
--- a/pkg/schema_store/utils.go
+++ b/pkg/schema_store/utils.go
@@ -178,7 +178,10 @@ func GetTableDefFromDB(db *sql.DB, dbName string, tableName string) (*Table, err
 		} else {
 			column.IsPrimaryKey = false
 		}
-		if extra.Valid && strings.Contains(strings.ToUpper(extra.String), "GENERATED") {
+
+		// TiDB describes certain column as `DEFAULT_GENERATED`
+		if extra.Valid && (strings.Contains(strings.ToUpper(extra.String), "VIRTUAL GENERATED") ||
+			strings.Contains(strings.ToUpper(extra.String), "STORED GENERATED")) {
 			column.IsGenerated = true
 		}
 

--- a/pkg/sql_execution_engine/internal_txn_tagger.go
+++ b/pkg/sql_execution_engine/internal_txn_tagger.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 
 	"github.com/juju/errors"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/moiot/gravity/pkg/utils"
 )
@@ -47,6 +48,9 @@ func ExecWithInternalTxnTag(
 	}
 
 	if !internalTxnTaggerCfg.TagInternalTxn {
+		if log.IsLevelEnabled(log.DebugLevel) {
+			log.Debugf("query: %v, args: %v", newQuery, args)
+		}
 		_, err := db.Exec(newQuery, args...)
 		return errors.Annotatef(err, "query: %v, args: %v", query, args)
 	}
@@ -64,6 +68,9 @@ func ExecWithInternalTxnTag(
 		return errors.Trace(err)
 	}
 
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.Debugf("query: %v, args: %v", newQuery, args)
+	}
 	_, err = txn.Exec(query, args...)
 	if err != nil {
 		txn.Rollback()


### PR DESCRIPTION
this closes #289 

for datetime column with `DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP` property, TiDB show it as `DEFAULT_GENERATED on update CURRENT_TIMESTAMP` in meta data. There might be other cases I'm not sure but anyway  it must be distinguished from MySQL `STORED GENERATED` and `VIRTUAL GENERATED` columns.