### PR TITLE
fix(schema_store): uniqueKeyMap ignored appended column

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/xdg/stringprep v1.0.0 // indirect
 	go.mongodb.org/mongo-driver v1.0.1
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
+	golang.org/x/sys v0.6.0 // indirect
 	google.golang.org/grpc v1.26.0
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce

--- a/go.sum
+++ b/go.sum
@@ -801,6 +801,8 @@ golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/pkg/inputs/mysqlstream/binlog_tailer.go
+++ b/pkg/inputs/mysqlstream/binlog_tailer.go
@@ -666,9 +666,6 @@ func (tailer *BinlogTailer) FlushMsgTxnBuffer() {
 		}
 		log.Debugf("[binlogTailer] ignore internal traffic")
 		tailer.msgTxnBuffer = []*core.Msg{lastMsg}
-	} else {
-		log.Debugf("[binlogTailer] do not ignore traffic: hasInternalTxnTag %v, cfg.Ignore %v, msgTxnBufferLen: %v",
-			hasInternalTxnTag, tailer.cfg.IgnoreBiDirectionalData, len(tailer.msgTxnBuffer))
 	}
 
 	for i, m := range tailer.msgTxnBuffer {

--- a/pkg/schema_store/utils.go
+++ b/pkg/schema_store/utils.go
@@ -106,8 +106,8 @@ func getUniqueKeysFromDB(db *sql.DB, dbName string, tableName string) (map[strin
 	for _, value := range resultRows {
 		keyName := value[2].String
 		columnName := value[4].String
-		if columns, ok := uniqueKeyMap[keyName]; ok {
-			columns = append(columns, columnName)
+		if _, ok := uniqueKeyMap[keyName]; ok {
+			uniqueKeyMap[keyName] = append(uniqueKeyMap[keyName], columnName)
 		} else {
 			uniqueKeyMap[keyName] = []string{columnName}
 		}

--- a/pkg/sql_execution_engine/utils.go
+++ b/pkg/sql_execution_engine/utils.go
@@ -96,6 +96,9 @@ func GetSingleSqlPlaceHolderAndArgWithEncodedData(msg *core.Msg, tableDef *schem
 			columnData, ok := data[columnName]
 			if !ok {
 				placeHolders = append(placeHolders, "DEFAULT")
+			} else if (column.Type == schema_store.TypeDatetime || column.Type == schema_store.TypeTimestamp) &&
+				column.DefaultVal.ValueString == "CURRENT_TIMESTAMP" {
+				placeHolders = append(placeHolders, "DEFAULT")
 			} else {
 				args = append(args, adjustArgs(columnData, &column))
 				placeHolders = append(placeHolders, "?")


### PR DESCRIPTION
Latter columns of composite unique key has been ignored because appending to the temp var :(. This makes a lot of fake latches that dramatically slows down the whole system.

fixes #334 